### PR TITLE
Check no stdclass charges MonetaryValue

### DIFF
--- a/src/Ups/Entity/Charges.php
+++ b/src/Ups/Entity/Charges.php
@@ -15,7 +15,7 @@ class Charges
             if (isset($response->CurrencyCode)) {
                 $this->CurrencyCode = $response->CurrencyCode;
             }
-            if (isset($response->MonetaryValue)) {
+            if (isset($response->MonetaryValue) && !$response->MonetaryValue instanceof \stdClass) {
                 $this->MonetaryValue = (float)$response->MonetaryValue;
             }
             if (isset($response->Code)) {
@@ -29,4 +29,4 @@ class Charges
             }
         }
     }
-} 
+}

--- a/src/Ups/Response.php
+++ b/src/Ups/Response.php
@@ -13,14 +13,14 @@ class Response implements ResponseInterface
     /**
      * @var SimpleXMLElement
      */
-    protected $reponse;
+    protected $response;
 
     /**
      * @return SimpleXMLElement
      */
     public function getResponse()
     {
-        return $this->reponse;
+        return $this->response;
     }
 
     /**
@@ -29,7 +29,7 @@ class Response implements ResponseInterface
      */
     public function setResponse(SimpleXMLElement $response)
     {
-        $this->reponse = $response;
+        $this->response = $response;
         return $this;
     }
 


### PR DESCRIPTION
Sometimes MonetaryValue is returned as stdClass, which gives 'Notice: Object of class stdClass could not be converted to double in /var/www/vendor/gabrielbull/ups-api/src/Ups/Entity/Charges.php on line 19'. Added a check to test if not stdClass, assuming then it will be a string.