### PR TITLE
Dimensions are not required in Rate API

### DIFF
--- a/src/Ups/Entity/Package.php
+++ b/src/Ups/Entity/Package.php
@@ -191,7 +191,7 @@ class Package implements NodeInterface
     }
 
     /**
-     * @return Dimensions
+     * @return Dimensions|null
      */
     public function getDimensions()
     {

--- a/src/Ups/Entity/Package.php
+++ b/src/Ups/Entity/Package.php
@@ -73,7 +73,7 @@ class Package implements NodeInterface
     private $largePackage;
 
     /**
-     * @var Dimensions
+     * @var Dimensions|null
      */
     private $dimensions;
 
@@ -89,7 +89,6 @@ class Package implements NodeInterface
     {
         $this->setPackagingType(new PackagingType);
         $this->setReferenceNumber(new ReferenceNumber);
-        $this->setDimensions(new Dimensions);
         $this->setPackageWeight(new PackageWeight);
         $this->setPackageServiceOptions(new PackageServiceOptions);
 
@@ -146,7 +145,9 @@ class Package implements NodeInterface
 
         $node->appendChild($this->getPackagingType()->toNode($document));
         $node->appendChild($this->getPackageWeight()->toNode($document));
-        $node->appendChild($this->getDimensions()->toNode($document));
+        if (null !== $this->getDimensions()) {
+            $node->appendChild($this->getDimensions()->toNode($document));
+        }
         $node->appendChild($this->getPackageServiceOptions()->toNode($document));
         return $node;
     }


### PR DESCRIPTION
Current library implementation gives `Failure (Hard): LBS is not a valid unit of measurement for dimensions for this shipment` error from UPS response if user didn't set the dimensions (`$package->setDimensions($dimensions)`). 

According to "Rating Package developers guide", page 44, /RateRequest/Shipment/Package/Dimensions not required.

This fix allows user not to specify the package dimensions.