### PR TITLE
Only add package reference number to XML when Code & Value are set

### DIFF
--- a/src/Ups/Shipping.php
+++ b/src/Ups/Shipping.php
@@ -335,7 +335,7 @@ class Shipping extends Ups
                 $node->appendChild($xml->createElement('LargePackageIndicator'));
             }
 
-            if (isset($package->ReferenceNumber)) {
+            if (isset($package->ReferenceNumber) && isset($package->ReferenceNumber->Code) && isset($package->ReferenceNumber->Value)) {
                 $refNode = $node->appendChild($xml->createElement('ReferenceNumber'));
 
                 if ($package->ReferenceNumber->BarCodeIndicator) {


### PR DESCRIPTION
While testing I get this error from the API: 'Failure (120542: Hard): Package/ReferenceNumber is not allowed for this shipment'

It seems that not in all cases the tags for ReferenceNumber are allowed, even not empty. Change checks if Code & Value are set, that are the required nodes for this ReferenceNumber node.