### PR TITLE
Add ResidentialAddress to default address generator (if indicator set)

### DIFF
--- a/src/Ups/Shipping.php
+++ b/src/Ups/Shipping.php
@@ -163,10 +163,6 @@ class Shipping extends Ups
 
         $addressNode = $xml->importNode($this->compileAddressNode($shipment->ShipTo->Address), true);
 
-        if (isset($shipment->ShipTo->ResidentialAddress)) {
-            $addressNode->appendChild($xml->createElement('ResidentialAddress'));
-        }
-
         if (isset($shipment->ShipTo->LocationID)) {
             $addressNode->appendChild($xml->createElement('LocationID', strtoupper($shipment->ShipTo->LocationID)));
         }
@@ -654,6 +650,10 @@ class Shipping extends Ups
 
         if (isset($address->CountryCode)) {
             $node->appendChild($xml->createElement('CountryCode', $address->CountryCode));
+        }
+
+        if(isset($address->ResidentialAddressIndicator)) {
+            $node->appendChild($xml->createElement('ResidentialAddress'));
         }
 
         return $node->cloneNode(true);


### PR DESCRIPTION
ResidentialAddress was missing in the ShipTo (Shipping Class), so adjusted it that in all address generators for that class the XML node is added when the indicator is available.