### PR TITLE
Added ShipmentServiceOptions to Shipping & Rate API

### DIFF
--- a/src/Ups/Entity/ShipmentServiceOptions.php
+++ b/src/Ups/Entity/ShipmentServiceOptions.php
@@ -1,12 +1,17 @@
 <?php
 namespace Ups\Entity;
 
-class ShipmentServiceOptions
+use DOMDocument;
+use DOMElement;
+use Ups\NodeInterface;
+
+class ShipmentServiceOptions implements NodeInterface
 {
     public $SaturdayPickup;
     public $SaturdayDelivery;
     public $CallTagARS;
     public $NegotiatedRatesIndicator;
+    public $DirectDeliveryOnlyIndicator;
 
     function __construct($response = null)
     {
@@ -25,6 +30,37 @@ class ShipmentServiceOptions
             if (isset($response->NegotiatedRatesIndicator)) {
                 $this->NegotiatedRatesIndicator = $response->NegotiatedRatesIndicator;
             }
+            if(isset($response->DirectDeliveryOnlyIndicator)) {
+                $this->DirectDeliveryOnlyIndicator = $response->DirectDeliveryOnlyIndicator;
+            }
         }
     }
+
+    /**
+     * @param null|DOMDocument $document
+     * @return DOMElement
+     */
+    public function toNode(DOMDocument $document = null)
+    {
+        if (null === $document) {
+            $document = new DOMDocument();
+        }
+
+        $node = $document->createElement('ShipmentServiceOptions');
+
+        if(isset($this->DirectDeliveryOnlyIndicator)) {
+            $node->appendChild($document->createElement('DirectDeliveryOnlyIndicator'));
+        }
+
+        if(isset($this->SaturdayPickup)) {
+            $node->appendChild($document->createElement('SaturdayPickup'));
+        }
+
+        if(isset($this->SaturdayDelivery)) {
+            $node->appendChild($document->createElement('SaturdayDelivery'));
+        }
+
+        return $node;
+    }
+
 }

--- a/src/Ups/Rate.php
+++ b/src/Ups/Rate.php
@@ -162,6 +162,11 @@ class Rate extends Ups
             $shipmentNode->appendChild($package->toNode($document));
         }
 
+        $shipmentServiceOptions = $shipment->getShipmentServiceOptions();
+        if(isset($shipmentServiceOptions)) {
+            $shipmentNode->appendChild($shipmentServiceOptions->toNode($xml));
+        }
+
         return $xml->saveXML();
     }
 

--- a/src/Ups/Shipping.php
+++ b/src/Ups/Shipping.php
@@ -351,6 +351,11 @@ class Shipping extends Ups
             }
         }
 
+        $shipmentServiceOptions = $shipment->getShipmentServiceOptions();
+        if(isset($shipmentServiceOptions)) {
+            $shipmentNode->appendChild($shipmentServiceOptions->toNode($xml));
+        }
+
         if ($labelSpecOpts) {
             $labelSpec = $container->appendChild($xml->createElement('LabelSpecification'));
 


### PR DESCRIPTION
For now only supports some of the ShipmentServiceOptions listed in the document. Quite a tedious work to add them all (over 6 pages full of nodes). Could be a base for other PRs.