### PR TITLE
Added XAV api wrapper

### DIFF
--- a/src/Ups/AddressValidation.php
+++ b/src/Ups/AddressValidation.php
@@ -1,0 +1,207 @@
+<?php
+namespace Ups;
+
+use DOMDocument;
+use SimpleXMLElement;
+use Exception;
+use stdClass;
+
+/**
+ * Address Validation API Wrapper
+ *
+ * @package ups
+ */
+class AddressValidation extends Ups
+{
+    const ENDPOINT = '/XAV';
+
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * @var ResponseInterface
+     * // todo make private
+     */
+    public $response;
+
+    /**
+        * @var int
+     */
+    private $requestOption; 
+    
+    /**
+        * @var address
+     */
+    private $address;
+    
+    /**
+        * @var int
+     */
+    private $maxSuggestion;
+    
+    /**
+     * @param string|null $accessKey UPS License Access Key
+     * @param string|null $userId UPS User ID
+     * @param string|null $password UPS User Password
+     * @param bool $useIntegration Determine if we should use production or CIE URLs.
+     * @param RequestInterface $request
+     */
+    public function __construct($accessKey = null, $userId = null, $password = null, $useIntegration = false, RequestInterface $request = null)
+    {
+        if (null !== $request) {
+            $this->setRequest($request);
+        }
+        parent::__construct($accessKey, $userId, $password, $useIntegration);
+    }
+
+    
+    /**
+     * Get package address suggestions from UPS
+     *
+     * @param Ups\Entity\Address $address The address to validate on street level.
+     * @param string $requestOption Optional processing. For Mail Innovations the only valid options are Last Activity and All activity.
+     * @return stdClass
+     * @throws Exception
+     */
+    public function validate($address, $requestOption = 1, $maxSuggestion = 5)
+    {
+        $this->address = $address;
+        $this->requestOption = $requestOption;
+        $this->maxSuggestion = $maxSuggestion;
+
+        $access = $this->createAccess();
+        $request = $this->createRequest();
+
+        $this->response = $this->getRequest()->request($access, $request, $this->compileEndpointUrl(self::ENDPOINT));
+        $response = $this->response->getResponse();
+
+        if (null === $response) {
+            throw new Exception("Failure (0): Unknown error", 0);
+        }
+
+        if ($response instanceof SimpleXMLElement && $response->Response->ResponseStatusCode == 0) {
+            throw new Exception(
+                "Failure ({$response->Response->Error->ErrorSeverity}): {$response->Response->Error->ErrorDescription}",
+                (int)$response->Response->Error->ErrorCode
+            );
+        } else {
+            return $this->formatResponse($response);
+        }
+    }
+    
+    
+    /**
+     * Create the XAV request
+     *
+     * @return string
+     */
+    private function createRequest()
+    {
+        $xml = new DOMDocument();
+        $xml->formatOutput = true;
+
+        $avRequest = $xml->appendChild($xml->createElement("AddressValidationRequest"));
+        $avRequest->setAttribute('xml:lang', 'en-US');
+
+        $request = $avRequest->appendChild($xml->createElement("Request"));
+
+        $node = $xml->importNode($this->createTransactionNode(), true);
+        $request->appendChild($node);
+
+        $request->appendChild($xml->createElement("RequestAction", "XAV"));
+
+        if (null !== $this->requestOption) {
+            $request->appendChild($xml->createElement("RequestOption", $this->requestOption));
+        }
+        
+        if (null !== $this->maxSuggestion) {
+            $avRequest->appendChild($xml->createElement("MaximumListSize", $this->maxSuggestion));
+        }
+        
+        if (null !== $this->address) {
+            $addressNode = $avRequest->appendChild($xml->createElement("AddressKeyFormat"));
+            
+            if($this->address->getAttentionName()) {
+                $addressNode->appendChild($xml->createElement("ConsigneeName", $this->address->getAttentionName()));
+            }            
+            if($this->address->getBuildingName()) {
+                $addressNode->appendChild($xml->createElement("BuildingName", $this->address->getBuildingName()));
+            }            
+            if($this->address->getAddressLine1()) {
+                $addressNode->appendChild($xml->createElement("AddressLine", $this->address->getAddressLine1()));
+            }             
+            if($this->address->getAddressLine2()) {
+                $addressNode->appendChild($xml->createElement("AddressLine", $this->address->getAddressLine2()));
+            }            
+            if($this->address->getAddressLine3()) {
+                $addressNode->appendChild($xml->createElement("AddressLine", $this->address->getAddressLine3()));
+            }            
+            if($this->address->getStateProvinceCode()) {
+                $addressNode->appendChild($xml->createElement("PoliticalDivision2", $this->address->getStateProvinceCode()));
+            }            
+            if($this->address->getCity()) {
+                $addressNode->appendChild($xml->createElement("PoliticalDivision1", $this->address->getCity()));
+            }            
+            if($this->address->getCountryCode()) {
+                $addressNode->appendChild($xml->createElement("CountryCode", $this->address->getCountryCode()));
+            }
+            if($this->address->getPostalCode()) {
+                $addressNode->appendChild($xml->createElement("PostcodePrimaryLow", $this->address->getPostalCode()));
+            }
+        }
+        
+        return $xml->saveXML();
+    }
+
+    /**
+     * Format the response
+     *
+     * @param SimpleXMLElement $response
+     * @return stdClass
+     */
+    private function formatResponse(SimpleXMLElement $response)
+    {
+        return $this->convertXmlObject($response->AddressKeyFormat);
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    public function getRequest()
+    {
+        if (null === $this->request) {
+            $this->request = new Request;
+        }
+        return $this->request;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return $this
+     */
+    public function setRequest(RequestInterface $request)
+    {
+        $this->request = $request;
+        return $this;
+    }
+
+    /**
+     * @return ResponseInterface
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @return $this
+     */
+    public function setResponse(ResponseInterface $response)
+    {
+        $this->response = $response;
+        return $this;
+    }
+}


### PR DESCRIPTION
New AddressValidation class for XAV request on UPS Api.
Used Tracking class structure as a base to keep it close. 

Here is a code sample, using Address entity then appending to XAV request, UPS returns XML of suggested address with corrected errors.


    $address = new \Ups\Entity\Address();

    $address->setAttentionName('Xxxxxxxx Xxxxxxxx');
    $address->setBuildingName('Xxxxxxxxxxxxxxxxx');
    $address->setAddressLine1('0000 xxxxxxxxxxxxxxxxxxx ');
    $address->setAddressLine2('xxxx');
    $address->setAddressLine3('xxxx');
    $address->setStateProvinceCode('XX');       
    $address->setCity('Xxx Xxxxxxxxxxxx');     
    $address->setCountryCode('XX');
    $address->setPostalCode('00000');

    $xavRequest = new \Ups\AddressValidation($accessKey, $userId, $password);
    $xavResponse = $xavRequest->validate($address);