### PR TITLE
Allow empty string for ResidentialAddressIndicator

### DIFF
--- a/src/Ups/Entity/Address.php
+++ b/src/Ups/Entity/Address.php
@@ -286,7 +286,7 @@ class Address implements NodeInterface
         if ($this->getCountryCode()) {
             $node->appendChild($document->createElement('CountryCode', $this->getCountryCode()));
         }
-        if($this->getResidentialAddressIndicator()) {
+        if(!is_null($this->getResidentialAddressIndicator())) {
             $node->appendChild($document->createElement('ResidentialAddressIndicator'));
         }
         return $node;


### PR DESCRIPTION
If the ResidentialAddressIndicator flag is set to an empty string the flag will not be addded to the XML document. By checking for Null this now works. The Developers Guide calls the flag a string with a length of 0 so I figured it was logical to allow the flag to be triggered with something like:  $address->setResidentialAddressIndicator('').

Side Note: This is my first pull request. Hopefully I'm doing this right. Thanks!