### PR TITLE
Fix required field rules for LabelSpec

### DIFF
--- a/src/Shipping.php
+++ b/src/Shipping.php
@@ -410,18 +410,21 @@ class Shipping extends Ups
                 $labelSpec->appendChild($xml->createElement('HTTPUserAgent', $labelSpecOpts->HTTPUserAgent));
             }
 
-            if (isset($labelSpecOpts->LabelStockSize)) {
-                $stock = $labelSpec->appendChild($xml->createElement('LabelStockSize'));
 
-                $stock->appendChild($xml->createElement('Height', $labelSpecOpts->LabelStockSize->Height));
-                $stock->appendChild($xml->createElement('Width', $labelSpecOpts->LabelStockSize->Width));
-            }
+            //Label print method is required only for GIF label formats
+            if ($labelSpecOpts->LabelPrintMethod->Code == 'GIF') {
+                $imageFormatNode = $labelSpec->appendChild($xml->createElement('LabelImageFormat'));
+                $node->appendChild($xml->createElement('Code', $labelSpecOpts->ImageFormat->Code));
 
-            $node = $labelSpec->appendChild($xml->createElement('LabelImageFormat'));
-            $node->appendChild($xml->createElement('Code', $labelSpecOpts->ImageFormat->Code));
+                if (isset($labelSpecOpts->ImageFormat->Description)) {
+                    $imageFormatNode->appendChild($xml->createElement('Description', $labelSpecOpts->ImageFormat->Description));
+                }
+            } else {
+                //Label stock size is required only for non-GIF label formats
+                $stockSizeNode = $labelSpec->appendChild($xml->createElement('LabelStockSize'));
 
-            if (isset($labelSpecOpts->ImageFormat->Description)) {
-                $node->appendChild($xml->createElement('Description', $labelSpecOpts->ImageFormat->Description));
+                $stockSizeNode->appendChild($xml->createElement('Height', $labelSpecOpts->LabelStockSize->Height));
+                $stockSizeNode->appendChild($xml->createElement('Width', $labelSpecOpts->LabelStockSize->Width));
             }
 
             if (isset($labelSpecOpts->Instruction)) {


### PR DESCRIPTION
As per Shipping Package XML Developers Guide ( 07/13/2015 ):

`/ShipmentConfirmRequest/LabelSpecification/LabelImageFormat/Code`
Required?: **Cond**
*Code type that the label image is to be generated in.*
Required if **ShipmentConfirmRequest/LabelSpecification/LabelPrintMethod/Code = GIF**. Valid values are GIF or PNG. Only GIF is supported on the remote server.

and

`/ShipmentConfirmRequest/LabelSpecification/LabelStockSize`
Required?: **Cond**
*Container for the EPL2, ZPL, STARPL or SPL label size*
**For EPL2, ZPL, STARPL and SPL labels.**

Thus, one does not have to provide the `LabelImageFormat/Code` if **EPL**, **ZPL** or **SPL** (or rather any that is not **GIF**) label format is used, but the `LabelStockSize/Height` and `LabelStockSize/Width` are required then.