### PR TITLE
Shipping class refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # CHANGELOG
 
-## 0.5.1 (upcoming release)
+## 0.6.0 (upcoming)
+- Added ShipmentRequestLabelSpecification class for easier options setting
+- Added ShipmentRequestReceiptSpecification class for easier options setting
+- **[!]** Shipment class dropped some public properties in favor of private properties and setter/getter methods.
+- **[!]** `confirm` and `accept` methods of Shipping class now receive Shipment, ShipmentRequestLabelSpecification and
+ShipmentRequestReceiptSpecification
 
+Items marked with **[!]**  may and will incur backwards incompatibility.
 
 ## 0.5.0 (released 26-08-2015)
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
     {
       "name": "Stefan Doorn",
       "email": "stefan@efectos.nl"
+    },
+    {
+      "name": "Eduard Sukharev",
+      "email": "sukharev.eh@gmail.com"
     }
   ],
   "require": {

--- a/src/Entity/BillShipper.php
+++ b/src/Entity/BillShipper.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright © Eduard Sukharev
+ *
+ * For a full license, see the LICENSE file.
+ */
+
+namespace Ups\Entity;
+
+/**
+ * @author Eduard Sukharev <eduard.sukharev@opensoftdev.ru>
+ */
+class BillShipper
+{
+    /**
+     * @var string
+     */
+    private $accountNumber;
+
+    /**
+     * @var CreditCard
+     */
+    private $creditCard;
+
+    public function __construct($attributes = null)
+    {
+        if (isset($attributes->AccountNumber)) {
+            $this->setAccountNumber($attributes->AccountNumber);
+        }
+        if (isset($attributes->CreditCard)) {
+            $this->setAccountNumber(new CreditCard($attributes->CreditCard));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountNumber()
+    {
+        return $this->accountNumber;
+    }
+
+    /**
+     * @param string $accountNumber
+     *
+     * @return BillShipper
+     */
+    public function setAccountNumber($accountNumber)
+    {
+        $this->accountNumber = $accountNumber;
+
+        return $this;
+    }
+
+    /**
+     * @return CreditCard
+     */
+    public function getCreditCard()
+    {
+        return $this->creditCard;
+    }
+
+    /**
+     * @param CreditCard $creditCard
+     * @return BillShipper
+     */
+    public function setCreditCard(CreditCard $creditCard)
+    {
+        $this->creditCard = $creditCard;
+
+        return $this;
+    }
+}

--- a/src/Entity/BillThirdParty.php
+++ b/src/Entity/BillThirdParty.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright © Eduard Sukharev
+ *
+ * For a full license, see the LICENSE file.
+ */
+
+namespace Ups\Entity;
+
+/**
+ * @author Eduard Sukharev <eduard.sukharev@opensoftdev.ru>
+ */
+class BillThirdParty
+{
+    /**
+     * @var Address
+     */
+    private $thirdPartyAddress;
+
+    /**
+     * @var string
+     */
+    private $accountNumber;
+
+    public function __construct($attributes = null)
+    {
+        $this->thirdPartyAddress = new Address(isset($attributes->Address) ? $attributes->Address : null);
+        $this->accountNumber = isset($attributes->AccountNumber) ? $attributes->AccountNumber : null;
+    }
+
+    /**
+     * @return Address
+     */
+    public function getThirdPartyAddress()
+    {
+        return $this->thirdPartyAddress;
+    }
+
+    /**
+     * @param Address $thirdPartyAddress
+     * @return BillThirdParty
+     */
+    public function setThirdPartyAddress(Address $thirdPartyAddress = null)
+    {
+        $this->thirdPartyAddress = $thirdPartyAddress;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountNumber()
+    {
+        return $this->accountNumber;
+    }
+
+    /**
+     * @param string $accountNumber
+     * @return BillThirdParty
+     */
+    public function setAccountNumber($accountNumber)
+    {
+        $this->accountNumber = $accountNumber;
+
+        return $this;
+    }
+}

--- a/src/Entity/CreditCard.php
+++ b/src/Entity/CreditCard.php
@@ -1,0 +1,152 @@
+<?php
+/*
+ * Copyright © Eduard Sukharev
+ *
+ * For a full license, see the LICENSE file.
+ */
+
+namespace Ups\Entity;
+
+/**
+ * @author Eduard Sukharev <eduard.sukharev@opensoftdev.ru>
+ */
+class CreditCard
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $number;
+
+    /**
+     * @var string
+     */
+    private $expirationDate;
+
+    /**
+     * @var string
+     */
+    private $securityCode;
+
+    /**
+     * @var Address
+     */
+    private $address;
+
+    public function __construct($attributes = null)
+    {
+        $this->setAddress(new Address(isset($attributes->Address) ? $attributes->Address : null));
+
+        if (isset($attributes->Type)) {
+            $this->setType($attributes->Type);
+        }
+        if (isset($attributes->Number)) {
+            $this->setNumber($attributes->Number);
+        }
+        if (isset($attributes->ExpirationDate)) {
+            $this->setExpirationDate($attributes->ExpirationDate);
+        }
+        if (isset($attributes->SecurityCode)) {
+            $this->setSecurityCode($attributes->SecurityCode);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     * @return CreditCard
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumber()
+    {
+        return $this->number;
+    }
+
+    /**
+     * @param string $number
+     * @return CreditCard
+     */
+    public function setNumber($number)
+    {
+        $this->number = $number;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecurityCode()
+    {
+        return $this->securityCode;
+    }
+
+    /**
+     * @param string $securityCode
+     * @return CreditCard
+     */
+    public function setSecurityCode($securityCode)
+    {
+        $this->securityCode = $securityCode;
+
+        return $this;
+    }
+
+    /**
+     * @return Address
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    /**
+     * @param Address $address
+     * @return CreditCard
+     */
+    public function setAddress(Address $address)
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpirationDate()
+    {
+        return $this->expirationDate;
+    }
+
+    /**
+     * @param string $expirationDate
+     * @return CreditCard
+     */
+    public function setExpirationDate($expirationDate)
+    {
+        $this->expirationDate = $expirationDate;
+
+        return $this;
+    }
+}

--- a/src/Entity/Dimensions.php
+++ b/src/Entity/Dimensions.php
@@ -8,15 +8,19 @@ use Ups\NodeInterface;
 
 class Dimensions implements NodeInterface
 {
-    /** @deprecated */
-    public $Length;
-    /** @deprecated */
-    public $Width;
-    /** @deprecated */
-    public $Height;
-
+    /**
+     * @var integer
+     */
     private $length;
+
+    /**
+     * @var integer
+     */
     private $width;
+
+    /**
+     * @var integer
+     */
     private $height;
 
     /**
@@ -83,36 +87,60 @@ class Dimensions implements NodeInterface
         return $this;
     }
 
+    /**
+     * @return integer
+     */
     public function getLength()
     {
         return $this->length;
     }
 
+    /**
+     * @param integer $var
+     * @return Dimensions
+     */
     public function setLength($var)
     {
         $this->length = $var;
-        $this->Length = $var;
+
+        return $this;
     }
 
+    /**
+     * @return integer
+     */
     public function getWidth()
     {
         return $this->width;
     }
 
+    /**
+     * @param integer $var
+     * @return Dimensions
+     */
     public function setWidth($var)
     {
-        $this->Width = $var;
         $this->width = $var;
+
+        return $this;
     }
 
+    /**
+     * @return integer
+     */
     public function getHeight()
     {
         return $this->height;
     }
 
+    /**
+     * @param integer $var
+     * @return Dimensions
+     */
     public function setHeight($var)
     {
         $this->height = $var;
-        $this->Height = $var;
+
+        return $this;
     }
 }

--- a/src/Entity/FreightCollect.php
+++ b/src/Entity/FreightCollect.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright © Eduard Sukharev
+ *
+ * For a full license, see the LICENSE file.
+ */
+
+
+namespace Ups\Entity;
+
+/**
+ * @author Eduard Sukharev <eduard.sukharev@opensoftdev.ru>
+ */
+class FreightCollect
+{
+    /**
+     * @var string
+     */
+    private $accountNumber;
+
+    /**
+     * @var Address
+     */
+    private $billReceiverAddress;
+
+    public function __construct($attributes = null)
+    {
+        if (isset($attributes->AccountNumber)) {
+            $this->setAccountNumber($attributes->AccountNumber);
+        }
+        if (isset($attributes->BillReceiverAddress)) {
+            $this->setBillReceiverAddress(new Address($attributes->BillReceiverAddress));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountNumber()
+    {
+        return $this->accountNumber;
+    }
+
+    /**
+     * @param string $accountNumber
+     * @return FreightCollect
+     */
+    public function setAccountNumber($accountNumber)
+    {
+        $this->accountNumber = $accountNumber;
+
+        return $this;
+    }
+
+    /**
+     * @return Address
+     */
+    public function getBillReceiverAddress()
+    {
+        return $this->billReceiverAddress;
+    }
+
+    /**
+     * @param Address $address
+     * @return FreightCollect
+     */
+    public function setBillReceiverAddress(Address $address = null)
+    {
+        $this->billReceiverAddress = $address;
+
+        return $this;
+    }
+}

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -12,27 +12,6 @@ class Package implements NodeInterface
     const PKG_OVERSIZE2 = '2';
     const PKG_LARGE = '4';
 
-    /** @deprecated */
-    public $PackagingType;
-    /** @deprecated */
-    public $PackageWeight;
-    /** @deprecated */
-    public $Description;
-    /** @deprecated */
-    public $PackageServiceOptions;
-    /** @deprecated */
-    public $UPSPremiumCareIndicator;
-    /** @deprecated */
-    public $ReferenceNumber;
-    /** @deprecated */
-    public $TrackingNumber;
-    /** @deprecated */
-    public $LargePackage;
-    /** @deprecated */
-    public $Dimensions;
-    /** @deprecated */
-    public $Activity;
-
     /**
      * @var PackagingType
      */
@@ -69,9 +48,14 @@ class Package implements NodeInterface
     private $trackingNumber;
 
     /**
-     * @var string
+     * @var bool
      */
-    private $largePackage;
+    private $isLargePackage;
+
+    /**
+     * @var bool
+     */
+    private $additionalHandling;
 
     /**
      * @var Dimensions|null
@@ -145,16 +129,39 @@ class Package implements NodeInterface
             $document = new DOMDocument();
         }
 
-        $node = $document->createElement('Package');
+        $packageNode = $document->createElement('Package');
 
-        $node->appendChild($this->getPackagingType()->toNode($document));
-        $node->appendChild($this->getPackageWeight()->toNode($document));
-        if (null !== $this->getDimensions()) {
-            $node->appendChild($this->getDimensions()->toNode($document));
+        if ($this->getDescription()) {
+            $packageNode->appendChild($document->createElement('Description', $this->getDescription()));
         }
-        $node->appendChild($this->getPackageServiceOptions()->toNode($document));
+        $packageNode->appendChild($this->getPackagingType()->toNode($document));
+        $packageNode->appendChild($this->getPackageWeight()->toNode($document));
 
-        return $node;
+
+        if (null !== $this->getDimensions()) {
+            $packageNode->appendChild($this->getDimensions()->toNode($document));
+        }
+
+        if ($this->isLargePackage()) {
+            $packageNode->appendChild($document->createElement('LargePackageIndicator'));
+        }
+
+        if ($this->getAdditionalHandling()) {
+            $packageNode->appendChild($document->createElement('AdditionalHandling'));
+        }
+
+        if ($this->getPackageServiceOptions()) {
+            $packageNode->appendChild($this->getPackageServiceOptions()->toNode($document));
+        }
+
+        if ($this->getReferenceNumber()
+            && !is_null($this->getReferenceNumber()->getCode())
+            && !is_null($this->getReferenceNumber()->getValue())
+        ) {
+            $packageNode->appendChild($this->getReferenceNumber()->toNode($document));
+        }
+
+        return $packageNode;
     }
 
     /**
@@ -168,11 +175,10 @@ class Package implements NodeInterface
     /**
      * @param Activity[] $activities
      *
-     * @return $this
+     * @return Package
      */
-    public function setActivities($activities)
+    public function setActivities(array $activities)
     {
-        $this->Activity = $activities;
         $this->activities = $activities;
 
         return $this;
@@ -189,11 +195,10 @@ class Package implements NodeInterface
     /**
      * @param string $description
      *
-     * @return $this
+     * @return Package
      */
     public function setDescription($description)
     {
-        $this->Description = $description;
         $this->description = $description;
 
         return $this;
@@ -210,33 +215,31 @@ class Package implements NodeInterface
     /**
      * @param Dimensions $dimensions
      *
-     * @return $this
+     * @return Package
      */
     public function setDimensions(Dimensions $dimensions)
     {
-        $this->Dimensions = $dimensions;
         $this->dimensions = $dimensions;
 
         return $this;
     }
 
     /**
-     * @return string
+     * @return bool
      */
-    public function getLargePackage()
+    public function isLargePackage()
     {
-        return $this->largePackage;
+        return $this->isLargePackage;
     }
 
     /**
-     * @param string $largePackage
+     * @param bool $largePackage
      *
-     * @return $this
+     * @return Package
      */
     public function setLargePackage($largePackage)
     {
-        $this->LargePackage = $largePackage;
-        $this->largePackage = $largePackage;
+        $this->isLargePackage = $largePackage;
 
         return $this;
     }
@@ -252,11 +255,10 @@ class Package implements NodeInterface
     /**
      * @param PackageServiceOptions $packageServiceOptions
      *
-     * @return $this
+     * @return Package
      */
     public function setPackageServiceOptions(PackageServiceOptions $packageServiceOptions)
     {
-        $this->PackageServiceOptions = $packageServiceOptions;
         $this->packageServiceOptions = $packageServiceOptions;
 
         return $this;
@@ -273,11 +275,10 @@ class Package implements NodeInterface
     /**
      * @param PackageWeight $packageWeight
      *
-     * @return $this
+     * @return Package
      */
     public function setPackageWeight(PackageWeight $packageWeight)
     {
-        $this->PackageWeight = $packageWeight;
         $this->packageWeight = $packageWeight;
 
         return $this;
@@ -294,11 +295,10 @@ class Package implements NodeInterface
     /**
      * @param PackagingType $packagingType
      *
-     * @return $this
+     * @return Package
      */
     public function setPackagingType(PackagingType $packagingType)
     {
-        $this->PackagingType = $packagingType;
         $this->packagingType = $packagingType;
 
         return $this;
@@ -315,11 +315,10 @@ class Package implements NodeInterface
     /**
      * @param ReferenceNumber $referenceNumber
      *
-     * @return $this
+     * @return Package
      */
     public function setReferenceNumber(ReferenceNumber $referenceNumber)
     {
-        $this->ReferenceNumber = $referenceNumber;
         $this->referenceNumber = $referenceNumber;
 
         return $this;
@@ -327,7 +326,6 @@ class Package implements NodeInterface
 
     public function removeReferenceNumber()
     {
-        $this->ReferenceNumber = null;
         $this->referenceNumber = null;
     }
 
@@ -342,11 +340,10 @@ class Package implements NodeInterface
     /**
      * @param string $trackingNumber
      *
-     * @return $this
+     * @return Package
      */
     public function setTrackingNumber($trackingNumber)
     {
-        $this->TrackingNumber = $trackingNumber;
         $this->trackingNumber = $trackingNumber;
 
         return $this;
@@ -363,13 +360,28 @@ class Package implements NodeInterface
     /**
      * @param string $upsPremiumCareIndicator
      *
-     * @return $this
+     * @return Package
      */
     public function setUpsPremiumCareIndicator($upsPremiumCareIndicator)
     {
-        $this->UPSPremiumCareIndicator = $upsPremiumCareIndicator;
         $this->upsPremiumCareIndicator = $upsPremiumCareIndicator;
 
         return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getAdditionalHandling()
+    {
+        return $this->additionalHandling;
+    }
+
+    /**
+     * @param boolean $additionalHandling
+     */
+    public function setAdditionalHandling($additionalHandling)
+    {
+        $this->additionalHandling = $additionalHandling;
     }
 }

--- a/src/Entity/PackageServiceOptions.php
+++ b/src/Entity/PackageServiceOptions.php
@@ -8,46 +8,48 @@ use Ups\NodeInterface;
 
 class PackageServiceOptions implements NodeInterface
 {
-    /** @deprecated */
-    public $COD;
-    /** @deprecated */
-    public $InsuredValue;
-    /** @deprecated */
-    public $EarliestDeliveryTime;
-    /** @deprecated */
-    public $HazardousMaterialsCode;
-    /** @deprecated */
-    public $HoldForPickup;
-
+    /**
+     * @var COD
+     */
     private $cod;
+
+    /**
+     * @var InsuredValue
+     */
     private $insuredValue;
+
+    /**
+     * @var string
+     */
     private $earliestDeliveryTime;
     private $hazardousMaterialsCode;
     private $holdForPickup;
 
-    public function __construct($response = null)
+    public function __construct($parameters = null)
     {
-        if (null != $response) {
-            if (isset($response->COD)) {
-                $this->setCOD(new COD($response->COD));
+        if (null != $parameters) {
+            if (isset($parameters->COD)) {
+                $this->setCOD(new COD($parameters->COD));
             }
-            if (isset($response->InsuredValue)) {
-                $this->setInsuredValue(new InsuredValue($response->InsuredValue));
+            if (isset($parameters->InsuredValue)) {
+                $this->setInsuredValue(new InsuredValue($parameters->InsuredValue));
             }
-            if (isset($response->EarliestDeliveryTime)) {
-                $this->setEarliestDeliveryTime($response->EarliestDeliveryTime);
+            if (isset($parameters->EarliestDeliveryTime)) {
+                $this->setEarliestDeliveryTime($parameters->EarliestDeliveryTime);
             }
-            if (isset($response->HazardousMaterialsCode)) {
-                $this->setHazardousMaterialsCode($response->HazardousMaterialsCode);
+            if (isset($parameters->HazardousMaterialsCode)) {
+                $this->setHazardousMaterialsCode($parameters->HazardousMaterialsCode);
             }
-            if (isset($response->HoldForPickup)) {
-                $this->setHoldForPickup($response->HoldForPickup);
+            if (isset($parameters->HoldForPickup)) {
+                $this->setHoldForPickup($parameters->HoldForPickup);
             }
         }
     }
 
     /**
      * @param null|DOMDocument $document
+     *
+     * TODO: this seem to be awfully incomplete
      *
      * @return DOMElement
      */
@@ -73,7 +75,6 @@ class PackageServiceOptions implements NodeInterface
 
     public function setInsuredValue($var)
     {
-        $this->InsuredValue = $var;
         $this->insuredValue = $var;
     }
 
@@ -84,7 +85,6 @@ class PackageServiceOptions implements NodeInterface
 
     public function setCOD($var)
     {
-        $this->COD = $var;
         $this->cod = $var;
     }
 
@@ -96,7 +96,6 @@ class PackageServiceOptions implements NodeInterface
     public function setEarliestDeliveryTime($var)
     {
         $this->earliestDeliveryTime = $var;
-        $this->EarliestDeliveryTime = $var;
     }
 
     public function getHazardousMaterialsCode()
@@ -106,7 +105,6 @@ class PackageServiceOptions implements NodeInterface
 
     public function setHazardousMaterialsCode($var)
     {
-        $this->HazardousMaterialsCode = $var;
         $this->hazardousMaterialsCode = $var;
     }
 
@@ -117,7 +115,6 @@ class PackageServiceOptions implements NodeInterface
 
     public function setHoldForPickup($var)
     {
-        $this->HoldForPickup = $var;
         $this->holdForPickup = $var;
     }
 }

--- a/src/Entity/PackagingType.php
+++ b/src/Entity/PackagingType.php
@@ -8,28 +8,62 @@ use Ups\NodeInterface;
 
 class PackagingType implements NodeInterface
 {
-    const PT_UNKONW = '00';
+    const PT_UNKNOWN = '00';
     const PT_UPSLETTER = '01';
     const PT_PACKAGE = '02';
     const PT_TUBE = '03';
     const PT_PAK = '04';
-    const PT_EXPRESSBOX = '21';
-    const PT_25KGBOX = '24';
-    const PT_10KGBOX = '25';
+    const PT_UPS_EXPRESSBOX = '21';
+    const PT_UPS_25KGBOX = '24';
+    const PT_UPS_10KGBOX = '25';
     const PT_PALLET = '30';
-    const PT_EXPRESSBOX_SM = '2a';
-    const PT_EXPRESSBOX_MD = '2b';
+    const PT_EXPRESSBOX_S = '2a';
+    const PT_EXPRESSBOX_M = '2b';
     const PT_EXPRESSBOX_L = '2c';
-
-    /** @deprecated */
-    public $Code = self::PT_UNKONW;
-    /** @deprecated */
-    public $Description;
+    const PT_FLATS = '56';
+    const PT_PARCELS = '57';
+    const PT_BPM = '58';
+    const PT_FIRST_CLASS = '59';
+    const PT_PRIORITY = '60';
+    const PT_MACHINABLES = '61';
+    const PT_IRREGULARS = '62';
+    const PT_PARCEL_POST = '63';
+    const PT_BPM_PARCEL = '64';
+    const PT_MEDIA_MAIL = '65';
+    const PT_BPM_FLAT = '66';
+    const PT_STANDARD_FLAT = '67';
 
     /**
+     * Required.
+     * Valid Package types values are:
+     * 01 = UPS Letter,
+     * 02 = Customer Supplied Package,
+     * 03 = Tube,
+     * 04 = PAK,
+     * 21 = UPS Express Box,
+     * 24 = UPS 25KG Box,
+     * 25 = UPS 10KG Box,
+     * 30 = Pallet,
+     * 2a = Small Express Box,
+     * 2b = Medium Express Box,
+     * 2c = Large Express Box,
+     * 56 = Flats,
+     * 57 = Parcels,
+     * 58 = BPM,
+     * 59 = First Class,
+     * 60 = Priority,
+     * 61 = Machinables,
+     * 62 = Irregulars,
+     * 63 = Parcel Post,
+     *
+     * 64 = BPM Parcel,
+     * 65 = Media Mail,
+     * 66 = BPM Flat,
+     * 67 = Standard Flat
+     *
      * @var string
      */
-    private $code = self::PT_UNKONW;
+    private $code = self::PT_UNKNOWN;
 
     /**
      * @var string

--- a/src/Entity/PaymentInformation.php
+++ b/src/Entity/PaymentInformation.php
@@ -2,23 +2,128 @@
 
 namespace Ups\Entity;
 
+use LogicException;
+
 class PaymentInformation
 {
-    public $Prepaid;
+    const TYPE_PREPAID = 'prepaid';
+    const TYPE_BILL_THIRD_PARTY = 'billThirdParty';
+    const TYPE_FREIGHT_COLLECT = 'freightCollect';
+    const TYPE_CONSIGNEE_BILLED = 'consigneeBilled';
 
-    public function __construct($type = 'prepaid', $attributes = null)
+    /**
+     * @var Prepaid
+     */
+    private $prepaid;
+
+    /**
+     * @var BillThirdParty
+     */
+    private $billThirdParty;
+
+    /**
+     * @var FreightCollect
+     */
+    private $freightCollect;
+
+    /**
+     * @var bool
+     */
+    private $consigneeBilled;
+
+    public function __construct($type = self::TYPE_PREPAID, $attributes = null)
     {
         switch ($type) {
-            case 'prepaid':
-                $this->Prepaid = new \stdClass();
-                $this->Prepaid->BillShipper = new \stdClass();
-                if (isset($attributes->AccountNumber)) {
-                    $this->Prepaid->BillShipper->AccountNumber = $attributes->AccountNumber;
-                }
-
+            case self::TYPE_PREPAID:
+                $this->prepaid = new Prepaid($attributes);
+                break;
+            case self::TYPE_BILL_THIRD_PARTY:
+                $this->billThirdParty = new BillThirdParty($attributes);
+                break;
+            case self::TYPE_FREIGHT_COLLECT:
+                $this->freightCollect = new FreightCollect($attributes);
+                break;
+            case self::TYPE_CONSIGNEE_BILLED:
+                $this->consigneeBilled = true;
                 break;
             default:
-                //TODO
+                throw new LogicException(sprintf('Unknown PaymentInformation type requested: "%s"', $type));
         }
+    }
+
+    /**
+     * @return Prepaid
+     */
+    public function getPrepaid()
+    {
+        return $this->prepaid;
+    }
+
+    /**
+     * @param Prepaid $prepaid
+     * @return PaymentInformation
+     */
+    public function setPrepaid(Prepaid $prepaid = null)
+    {
+        $this->prepaid = $prepaid;
+
+        return $this;
+    }
+
+    /**
+     * @return BillThirdParty
+     */
+    public function getBillThirdParty()
+    {
+        return $this->billThirdParty;
+    }
+
+    /**
+     * @param BillThirdParty $billThirdParty
+     * @return PaymentInformation
+     */
+    public function setBillThirdParty(BillThirdParty $billThirdParty = null)
+    {
+        $this->billThirdParty = $billThirdParty;
+
+        return $this;
+    }
+
+    /**
+     * @return FreightCollect
+     */
+    public function getFreightCollect()
+    {
+        return $this->freightCollect;
+    }
+
+    /**
+     * @param FreightCollect $freightCollect
+     * @return PaymentInformation
+     */
+    public function setFreightCollect(FreightCollect $freightCollect = null)
+    {
+        $this->freightCollect = $freightCollect;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getConsigneeBilled()
+    {
+        return $this->consigneeBilled;
+    }
+
+    /**
+     * @param bool $consigneeBilled
+     * @return PaymentInformation
+     */
+    public function setConsigneeBilled($consigneeBilled)
+    {
+        $this->consigneeBilled = $consigneeBilled;
+
+        return $this;
     }
 }

--- a/src/Entity/Prepaid.php
+++ b/src/Entity/Prepaid.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * Copyright © Eduard Sukharev
+ *
+ * For a full license, see the LICENSE file.
+ */
+
+namespace Ups\Entity;
+
+/**
+ * @author Eduard Sukharev <eduard.sukharev@opensoftdev.ru>
+ */
+class Prepaid
+{
+    /**
+     * @var BillShipper
+     */
+    private $billShipper;
+
+    public function __construct($attributes = null)
+    {
+        $this->setBillShipper(new BillShipper($attributes));
+    }
+
+    /**
+     * @return BillShipper
+     */
+    public function getBillShipper()
+    {
+        return $this->billShipper;
+    }
+
+    /**
+     * @param BillShipper $billShipper
+     */
+    public function setBillShipper($billShipper)
+    {
+        $this->billShipper = $billShipper;
+    }
+}

--- a/src/Entity/ReferenceNumber.php
+++ b/src/Entity/ReferenceNumber.php
@@ -9,26 +9,6 @@ use Ups\NodeInterface;
 class ReferenceNumber implements NodeInterface
 {
     /**
-     * @deprecated
-     */
-    public $Number;
-
-    /**
-     * @deprecated
-     */
-    public $Code;
-
-    /**
-     * @deprecated
-     */
-    public $Value;
-
-    /**
-     * @deprecated
-     */
-    public $BarCodeIndicator;
-
-    /**
      * Codes.
      */
     const CODE_ACCOUNTS_RECEIVABLE_CUSTOMER_ACCOUNT = 'AJ';
@@ -70,7 +50,7 @@ class ReferenceNumber implements NodeInterface
     private $barCodeIndicator;
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getCode()
     {
@@ -78,7 +58,7 @@ class ReferenceNumber implements NodeInterface
     }
 
     /**
-     * @param mixed $code
+     * @param string $code
      */
     public function setCode($code)
     {
@@ -86,7 +66,7 @@ class ReferenceNumber implements NodeInterface
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getValue()
     {
@@ -94,7 +74,7 @@ class ReferenceNumber implements NodeInterface
     }
 
     /**
-     * @param mixed $value
+     * @param string $value
      */
     public function setValue($value)
     {
@@ -102,7 +82,7 @@ class ReferenceNumber implements NodeInterface
     }
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function getBarCodeIndicator()
     {
@@ -110,7 +90,7 @@ class ReferenceNumber implements NodeInterface
     }
 
     /**
-     * @param mixed $barCodeIndicator
+     * @param bool $barCodeIndicator
      */
     public function setBarCodeIndicator($barCodeIndicator)
     {
@@ -124,16 +104,13 @@ class ReferenceNumber implements NodeInterface
     {
         if (null != $response) {
             if (isset($response->BarCodeIndicator)) {
-                $this->BarCodeIndicator = $response->BarCodeIndicator;
-            }
-            if (isset($response->Number)) {
-                $this->Number = $response->Number;
+                $this->setBarCodeIndicator($response->BarCodeIndicator);
             }
             if (isset($response->Code)) {
-                $this->Code = $response->Code;
+                $this->setCode($response->Code);
             }
             if (isset($response->Value)) {
-                $this->Value = $response->Value;
+                $this->setValue($response->Value);
             }
         }
     }

--- a/src/Entity/Shipment.php
+++ b/src/Entity/Shipment.php
@@ -4,25 +4,6 @@ namespace Ups\Entity;
 
 class Shipment
 {
-    /** @deprecated */
-    public $Description;
-    /** @deprecated */
-    public $Shipper;
-    /** @deprecated */
-    public $ShipTo;
-    /** @deprecated */
-    public $SoldTo;
-    /** @deprecated */
-    public $ShipFrom;
-    /** @deprecated */
-    public $Service;
-    /** @deprecated */
-    public $Package = [];
-    /** @deprecated */
-    public $ShipmentServiceOptions;
-    /** @deprecated */
-    public $PaymentInformation;
-
     /**
      * @var PaymentInformation
      */
@@ -98,6 +79,26 @@ class Shipment
      */
     private $shipmentServiceOptions;
 
+    /**
+     * @var bool
+     */
+    private $goodsNotInFreeCirculationIndicator;
+
+    /**
+     * @var string
+     */
+    private $movementReferenceNumber;
+
+    /**
+     * @var InvoiceLineTotal
+     */
+    private $invoiceLineTotal;
+
+    /**
+     * @var string
+     */
+    private $numOfPiecesInShipment;
+
     public function __construct()
     {
         $this->setShipper(new Shipper());
@@ -143,7 +144,7 @@ class Shipment
     /**
      * @param Package $package
      *
-     * @return $this
+     * @return Shipment
      */
     public function addPackage(Package $package)
     {
@@ -165,11 +166,10 @@ class Shipment
     /**
      * @param string $description
      *
-     * @return $this
+     * @return Shipment
      */
     public function setDescription($description)
     {
-        $this->Description = $description;
         $this->description = $description;
 
         return $this;
@@ -178,7 +178,7 @@ class Shipment
     /**
      * @param ReferenceNumber $referenceNumber
      *
-     * @return $this
+     * @return Shipment
      */
     public function setReferenceNumber(ReferenceNumber $referenceNumber)
     {
@@ -206,7 +206,7 @@ class Shipment
     /**
      * @param bool $documentsOnly
      *
-     * @return $this
+     * @return Shipment
      */
     public function setDocumentsOnly($documentsOnly)
     {
@@ -226,11 +226,10 @@ class Shipment
     /**
      * @param Package[] $packages
      *
-     * @return $this
+     * @return Shipment
      */
     public function setPackages(array $packages)
     {
-        $this->Package = $packages;
         $this->packages = $packages;
 
         return $this;
@@ -247,11 +246,10 @@ class Shipment
     /**
      * @param Service $service
      *
-     * @return $this
+     * @return Shipment
      */
     public function setService(Service $service)
     {
-        $this->Service = $service;
         $this->service = $service;
 
         return $this;
@@ -268,7 +266,7 @@ class Shipment
     /**
      * @param ReturnService $returnService
      *
-     * @return $this
+     * @return Shipment
      */
     public function setReturnService(ReturnService $returnService)
     {
@@ -288,11 +286,10 @@ class Shipment
     /**
      * @param ShipFrom $shipFrom
      *
-     * @return $this
+     * @return Shipment
      */
     public function setShipFrom(ShipFrom $shipFrom)
     {
-        $this->ShipFrom = $shipFrom;
         $this->shipFrom = $shipFrom;
 
         return $this;
@@ -309,11 +306,10 @@ class Shipment
     /**
      * @param ShipTo $shipTo
      *
-     * @return $this
+     * @return Shipment
      */
     public function setShipTo(ShipTo $shipTo)
     {
-        $this->ShipTo = $shipTo;
         $this->shipTo = $shipTo;
 
         return $this;
@@ -330,11 +326,10 @@ class Shipment
     /**
      * @param SoldTo $soldTo
      *
-     * @return $this
+     * @return Shipment
      */
     public function setSoldTo(SoldTo $soldTo)
     {
-        $this->SoldTo = $soldTo;
         $this->soldTo = $soldTo;
 
         return $this;
@@ -351,11 +346,10 @@ class Shipment
     /**
      * @param ShipmentServiceOptions $shipmentServiceOptions
      *
-     * @return $this
+     * @return Shipment
      */
     public function setShipmentServiceOptions(ShipmentServiceOptions $shipmentServiceOptions)
     {
-        $this->ShipmentServiceOptions = $shipmentServiceOptions;
         $this->shipmentServiceOptions = $shipmentServiceOptions;
 
         return $this;
@@ -372,11 +366,10 @@ class Shipment
     /**
      * @param Shipper $shipper
      *
-     * @return $this
+     * @return Shipment
      */
     public function setShipper(Shipper $shipper)
     {
-        $this->Shipper = $shipper;
         $this->shipper = $shipper;
 
         return $this;
@@ -393,11 +386,10 @@ class Shipment
     /**
      * @param PaymentInformation $paymentInformation
      *
-     * @return $this
+     * @return Shipment
      */
     public function setPaymentInformation(PaymentInformation $paymentInformation)
     {
-        $this->PaymentInformation = $paymentInformation;
         $this->paymentInformation = $paymentInformation;
 
         return $this;
@@ -423,11 +415,87 @@ class Shipment
     /**
      * @param RateInformation $rateInformation
      *
-     * @return $this
+     * @return Shipment
      */
     public function setRateInformation(RateInformation $rateInformation)
     {
         $this->rateInformation = $rateInformation;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getGoodsNotInFreeCirculationIndicator()
+    {
+        return $this->goodsNotInFreeCirculationIndicator;
+    }
+
+    /**
+     * @param boolean $goodsNotInFreeCirculationIndicator
+     * @return Shipment
+     */
+    public function setGoodsNotInFreeCirculationIndicator($goodsNotInFreeCirculationIndicator)
+    {
+        $this->goodsNotInFreeCirculationIndicator = $goodsNotInFreeCirculationIndicator;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMovementReferenceNumber()
+    {
+        return $this->movementReferenceNumber;
+    }
+
+    /**
+     * @param string $movementReferenceNumber
+     * @return Shipment
+     */
+    public function setMovementReferenceNumber($movementReferenceNumber)
+    {
+        $this->movementReferenceNumber = $movementReferenceNumber;
+
+        return $this;
+    }
+
+    /**
+     * @return InvoiceLineTotal
+     */
+    public function getInvoiceLineTotal()
+    {
+        return $this->invoiceLineTotal;
+    }
+
+    /**
+     * @param InvoiceLineTotal $invoiceLineTotal
+     * @return Shipment
+     */
+    public function setInvoiceLineTotal(InvoiceLineTotal $invoiceLineTotal)
+    {
+        $this->invoiceLineTotal = $invoiceLineTotal;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumOfPiecesInShipment()
+    {
+        return $this->numOfPiecesInShipment;
+    }
+
+    /**
+     * @param string $numOfPiecesInShipment
+     * @return Shipment
+     */
+    public function setNumOfPiecesInShipment($numOfPiecesInShipment)
+    {
+        $this->numOfPiecesInShipment = $numOfPiecesInShipment;
 
         return $this;
     }

--- a/src/Entity/ShipmentRequestLabelSpecification.php
+++ b/src/Entity/ShipmentRequestLabelSpecification.php
@@ -9,6 +9,7 @@
 namespace Ups\Entity;
 
 /**
+ * Based on UPS Developer Guide, dated: 13 Jul 2015
  * @author Eduard Sukharev <eduard.sukharev@opensoftdev.ru>
  */
 class ShipmentRequestLabelSpecification

--- a/src/Entity/ShipmentRequestLabelSpecification.php
+++ b/src/Entity/ShipmentRequestLabelSpecification.php
@@ -1,0 +1,275 @@
+<?php
+/*
+ * Copyright © Eduard Sukharev
+ *
+ * For a license agreement, see the LICENSE file.
+ */
+
+
+namespace Ups\Entity;
+
+/**
+ * @author Eduard Sukharev <eduard.sukharev@opensoftdev.ru>
+ */
+class ShipmentRequestLabelSpecification
+{
+    /**
+     * Required.
+     * Label print method code that the labels are to be generated. For EPL2 formatted labels use EPL, for SPL formatted
+     * labels use SPL, for ZPL formatted labels use ZPL, for STAR printer formatted labels use STARPL and for image
+     * formats use GIF.
+     *
+     * @var string
+     */
+    private $printMethodCode;
+
+    /**
+     * Optional.
+     * Label Specification Code description
+     *
+     * @var string
+     */
+    private $printMethodDescription;
+
+    /**
+     * Optional.
+     * Browser HTTPUserAgent String. This is the preferred way of identifying GIF image type to be generated
+     *
+     * @var string
+     */
+    private $httpUserAgent;
+
+    /**
+     * Required for EPL2, ZPL, STARPL and SPL labels.
+     * Height of the label image. For IN, use whole inches. Only valid value is 4.
+     * Label Image will only scale up to 4 X 6, even when requesting 4 X 8.
+     *
+     * @var string
+     */
+    private $stockSizeHeight;
+
+    /**
+     * Required for EPL2, ZPL, STARPL and SPL labels.
+     * Height of the label image. For IN, use whole inches. Only valid values are 6 or 8.
+     * Label Image will only scale up to 4 X 6, even when requesting 4 X 8.
+     *
+     * @var string
+     */
+    private $stockSizeWidth;
+
+    /**
+     * Required if $printMethodCode = GIF.
+     * Code type that the label image is to be generated in.
+     * Valid values are GIF or PNG. Only GIF is supported on the remote server.
+     *
+     * @var string
+     */
+    private $imageFormatCode;
+
+    /**
+     * Optional.
+     * Description of the label image format code.
+     *
+     * @var string
+     */
+    private $imageFormatDescription;
+
+    /**
+     * Optional.
+     * For Exchange Forward Shipment, Valid values are:
+     * 01 - EXCHANGE-LIKE ITEM ONLY.
+     * 02 - EXCHANGE-DRIVER INSTRUCTIONS INSIDE
+     * By default label will have Exchange Routing instruction Text as EXCHANGE-LIKE ITEM ONLY
+     *
+     * @var string
+     */
+    private $instructionCode;
+
+    /**
+     * Optional.
+     * Description of the label Instruction code.
+     *
+     * @var string
+     */
+    private $instructionDescription;
+
+    const PRINT_METHOD_CODE_EPL = 'EPL';
+    const PRINT_METHOD_CODE_SPL = 'SPL';
+    const PRINT_METHOD_CODE_ZPL = 'ZPL';
+    const PRINT_METHOD_CODE_STARPL = 'STARPL';
+    const PRINT_METHOD_CODE_GIF = 'GIF';
+
+    const IMG_FORMAT_CODE_GIF = 'GIF';
+    const IMG_FORMAT_CODE_PNG = 'PNG';
+
+    const INSTRUCTION_CODE_EXCHANGE_LIKE_ITEM_ONLY = '01';
+    const INSTRUCTION_CODE_EXCHANGE_DRIVER_INSTRUCTIONS_INSIDE = '02';
+
+    /**
+     * @param string $printMethodCode
+     */
+    public function __construct($printMethodCode)
+    {
+        $this->printMethodCode = $printMethodCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrintMethodCode()
+    {
+        return $this->printMethodCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrintMethodDescription()
+    {
+        return $this->printMethodDescription;
+    }
+
+    /**
+     * @param string $printMethodDescription
+     * @return ShipmentRequestLabelSpecification
+     */
+    public function setPrintMethodDescription($printMethodDescription)
+    {
+        $this->printMethodDescription = $printMethodDescription;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHttpUserAgent()
+    {
+        return $this->httpUserAgent;
+    }
+
+    /**
+     * @param string $httpUserAgent
+     * @return ShipmentRequestLabelSpecification
+     */
+    public function setHttpUserAgent($httpUserAgent)
+    {
+        $this->httpUserAgent = $httpUserAgent;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStockSizeHeight()
+    {
+        return $this->stockSizeHeight;
+    }
+
+    /**
+     * @param string $stockSizeHeight
+     * @return ShipmentRequestLabelSpecification
+     */
+    public function setStockSizeHeight($stockSizeHeight)
+    {
+        $this->stockSizeHeight = $stockSizeHeight;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStockSizeWidth()
+    {
+        return $this->stockSizeWidth;
+    }
+
+    /**
+     * @param string $stockSizeWidth
+     * @return ShipmentRequestLabelSpecification
+     */
+    public function setStockSizeWidth($stockSizeWidth)
+    {
+        $this->stockSizeWidth = $stockSizeWidth;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageFormatCode()
+    {
+        return $this->imageFormatCode;
+    }
+
+    /**
+     * @param string $imageFormatCode
+     * @return ShipmentRequestLabelSpecification
+     */
+    public function setImageFormatCode($imageFormatCode)
+    {
+        $this->imageFormatCode = $imageFormatCode;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageFormatDescription()
+    {
+        return $this->imageFormatDescription;
+    }
+
+    /**
+     * @param string $imageFormatDescription
+     * @return ShipmentRequestLabelSpecification
+     */
+    public function setImageFormatDescription($imageFormatDescription)
+    {
+        $this->imageFormatDescription = $imageFormatDescription;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInstructionCode()
+    {
+        return $this->instructionCode;
+    }
+
+    /**
+     * @param string $instructionCode
+     * @return ShipmentRequestLabelSpecification
+     */
+    public function setInstructionCode($instructionCode)
+    {
+        $this->instructionCode = $instructionCode;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInstructionDescription()
+    {
+        return $this->instructionDescription;
+    }
+
+    /**
+     * @param string $instructionDescription
+     * @return ShipmentRequestLabelSpecification
+     */
+    public function setInstructionDescription($instructionDescription)
+    {
+        $this->instructionDescription = $instructionDescription;
+
+        return $this;
+    }
+}

--- a/src/Entity/ShipmentRequestReceiptSpecification.php
+++ b/src/Entity/ShipmentRequestReceiptSpecification.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Copyright © Eduard Sukharev
+ *
+ * For a license agreement, see the LICENSE file.
+ */
+
+
+namespace Ups\Entity;
+
+/**
+ * @author Eduard Sukharev <eduard.sukharev@opensoftdev.ru>
+ */
+class ShipmentRequestReceiptSpecification
+{
+    /**
+     * Required.
+     * Print code that determines the receipt format.
+     * Valid Codes are: EPL, SPL, ZPL, STARPL and HTML.
+     *
+     * @var string
+     */
+    private $imageFormatCode;
+
+    /**
+     * Optional.
+     * Description of the receipt format code.
+     *
+     * @var string
+     */
+    private $imageFormatDescription;
+
+    const IMG_FORMAT_CODE_GIF = 'EPL';
+    const IMG_FORMAT_CODE_SPL = 'SPL';
+    const IMG_FORMAT_CODE_ZPL = 'ZPL';
+    const IMG_FORMAT_CODE_STARPL = 'STARPL';
+    const IMG_FORMAT_CODE_HTML = 'HTML';
+
+    /**
+     * @param string $imageFormatCode
+     */
+    public function __construct($imageFormatCode)
+    {
+        $this->imageFormatCode = $imageFormatCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageFormatCode()
+    {
+        return $this->imageFormatCode;
+    }
+    /**
+     * @return string
+     */
+    public function getImageFormatDescription()
+    {
+        return $this->imageFormatDescription;
+    }
+
+    /**
+     * @param string $imageFormatDescription
+     * @return ShipmentRequestReceiptSpecification
+     */
+    public function setImageFormatDescription($imageFormatDescription)
+    {
+        $this->imageFormatDescription = $imageFormatDescription;
+
+        return $this;
+    }
+}

--- a/src/Entity/Shipper.php
+++ b/src/Entity/Shipper.php
@@ -8,23 +8,6 @@ use Ups\NodeInterface;
 
 class Shipper implements NodeInterface
 {
-    /** @deprecated */
-    public $Name;
-    /** @deprecated */
-    public $AttentionName;
-    /** @deprecated */
-    public $TaxIdentificationNumber;
-    /** @deprecated */
-    public $PhoneNumber;
-    /** @deprecated */
-    public $FaxNumber;
-    /** @deprecated */
-    public $ShipperNumber;
-    /** @deprecated */
-    public $EMailAddress;
-    /** @deprecated */
-    public $Address;
-
     /**
      * @var string
      */
@@ -150,11 +133,10 @@ class Shipper implements NodeInterface
     /**
      * @param Address $address
      *
-     * @return $this
+     * @return Shipper
      */
     public function setAddress(Address $address)
     {
-        $this->Address = $address;
         $this->address = $address;
 
         return $this;
@@ -171,11 +153,10 @@ class Shipper implements NodeInterface
     /**
      * @param string $attentionName
      *
-     * @return $this
+     * @return Shipper
      */
     public function setAttentionName($attentionName)
     {
-        $this->AttentionName = $attentionName;
         $this->attentionName = $attentionName;
 
         return $this;
@@ -192,11 +173,10 @@ class Shipper implements NodeInterface
     /**
      * @param string $emailAddress
      *
-     * @return $this
+     * @return Shipper
      */
     public function setEmailAddress($emailAddress)
     {
-        $this->EMailAddress = $emailAddress;
         $this->emailAddress = $emailAddress;
 
         return $this;
@@ -213,11 +193,10 @@ class Shipper implements NodeInterface
     /**
      * @param string $faxNumber
      *
-     * @return $this
+     * @return Shipper
      */
     public function setFaxNumber($faxNumber)
     {
-        $this->FaxNumber = $faxNumber;
         $this->faxNumber = $faxNumber;
 
         return $this;
@@ -234,32 +213,11 @@ class Shipper implements NodeInterface
     /**
      * @param string $name
      *
-     * @return $this
+     * @return Shipper
      */
     public function setName($name)
     {
-        $this->Name = $name;
         $this->name = $name;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getCompanyName()
-    {
-        return $this->companyName;
-    }
-
-    /**
-     * @param string $companyName
-     *
-     * @return $this
-     */
-    public function setCompanyName($companyName)
-    {
-        $this->companyName = $companyName;
 
         return $this;
     }
@@ -275,11 +233,10 @@ class Shipper implements NodeInterface
     /**
      * @param string $phoneNumber
      *
-     * @return $this
+     * @return Shipper
      */
     public function setPhoneNumber($phoneNumber)
     {
-        $this->PhoneNumber = $phoneNumber;
         $this->phoneNumber = $phoneNumber;
 
         return $this;
@@ -296,11 +253,10 @@ class Shipper implements NodeInterface
     /**
      * @param string $shipperNumber
      *
-     * @return $this
+     * @return Shipper
      */
     public function setShipperNumber($shipperNumber)
     {
-        $this->ShipperNumber = $shipperNumber;
         $this->shipperNumber = $shipperNumber;
 
         return $this;
@@ -317,12 +273,30 @@ class Shipper implements NodeInterface
     /**
      * @param string $taxIdentificationNumber
      *
-     * @return $this
+     * @return Shipper
      */
     public function setTaxIdentificationNumber($taxIdentificationNumber)
     {
-        $this->TaxIdentificationNumber = $taxIdentificationNumber;
         $this->taxIdentificationNumber = $taxIdentificationNumber;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCompanyName()
+    {
+        return $this->companyName;
+    }
+
+    /**
+     * @param string $companyName
+     * @return Shipper
+     */
+    public function setCompanyName($companyName = null)
+    {
+        $this->companyName = $companyName;
 
         return $this;
     }

--- a/src/Entity/SoldTo.php
+++ b/src/Entity/SoldTo.php
@@ -87,6 +87,11 @@ class SoldTo implements NodeInterface
     private $address;
 
     /**
+     * @var string
+     */
+    private $option;
+
+    /**
      * @param null|object $attributes
      */
     public function __construct($attributes = null)
@@ -127,6 +132,9 @@ class SoldTo implements NodeInterface
             if (isset($attributes->Address)) {
                 $this->setAddress(new Address($attributes->Address));
             }
+            if (isset($attributes->Option)) {
+                $this->setOption($attributes->Option);
+            }
         }
     }
 
@@ -164,7 +172,7 @@ class SoldTo implements NodeInterface
     /**
      * @param Address $address
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setAddress(Address $address)
     {
@@ -185,7 +193,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $attentionName
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setAttentionName($attentionName)
     {
@@ -206,7 +214,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $bookmark
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setBookmark($bookmark)
     {
@@ -227,7 +235,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $companyName
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setCompanyName($companyName)
     {
@@ -248,7 +256,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $emailAddress
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setEmailAddress($emailAddress)
     {
@@ -269,7 +277,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $faxNumber
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setFaxNumber($faxNumber)
     {
@@ -290,7 +298,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $locationId
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setLocationId($locationId)
     {
@@ -311,7 +319,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $phoneNumber
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setPhoneNumber($phoneNumber)
     {
@@ -332,7 +340,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $receivingAddressName
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setReceivingAddressName($receivingAddressName)
     {
@@ -353,7 +361,7 @@ class SoldTo implements NodeInterface
     /**
      * @param string $shipperAssignedIdentificationNumber
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setShipperAssignedIdentificationNumber($shipperAssignedIdentificationNumber)
     {
@@ -374,12 +382,32 @@ class SoldTo implements NodeInterface
     /**
      * @param string $taxIdentificationNumber
      *
-     * @return $this
+     * @return SoldTo
      */
     public function setTaxIdentificationNumber($taxIdentificationNumber)
     {
         $this->TaxIdentificationNumber = $taxIdentificationNumber;
         $this->taxIdentificationNumber = $taxIdentificationNumber;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOption()
+    {
+        return $this->option;
+    }
+
+    /**
+     * @param string $option
+     *
+     * @return SoldTo
+     */
+    public function setOption($option)
+    {
+        $this->option = $option;
 
         return $this;
     }

--- a/src/Shipping.php
+++ b/src/Shipping.php
@@ -3,11 +3,16 @@
 namespace Ups;
 
 use DOMDocument;
+use DOMNode;
 use Exception;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 use stdClass;
+use Ups\Entity\Address;
+use Ups\Entity\LabelSpecification;
+use Ups\Entity\Package;
+use Ups\Entity\Shipment;
 use Ups\Entity\ShipmentRequestLabelSpecification;
 use Ups\Entity\ShipmentRequestReceiptSpecification;
 
@@ -62,7 +67,7 @@ class Shipping extends Ups
      * Create a Shipment Confirm request (generate a digest).
      *
      * @param string $validation A UPS_Shipping::REQ_* constant (or null)
-     * @param stdClass $shipment Shipment data container.
+     * @param Shipment $shipment Shipment data container.
      * @param ShipmentRequestLabelSpecification|null $labelSpec LabelSpecification data. Optional
      * @param ShipmentRequestReceiptSpecification|null $receiptSpec ShipmentRequestReceiptSpecification data. Optional
      *
@@ -72,7 +77,7 @@ class Shipping extends Ups
      */
     public function confirm(
         $validation,
-        $shipment,
+        Shipment $shipment,
         ShipmentRequestLabelSpecification $labelSpec = null,
         ShipmentRequestReceiptSpecification $receiptSpec = null
     ) {
@@ -98,7 +103,7 @@ class Shipping extends Ups
      * Creates a ShipConfirm request.
      *
      * @param string $validation
-     * @param stdClass $shipment
+     * @param Shipment $shipment
      * @param ShipmentRequestLabelSpecification|null $labelSpec
      * @param ShipmentRequestReceiptSpecification|null $receiptSpec
      *
@@ -106,7 +111,7 @@ class Shipping extends Ups
      */
     private function createConfirmRequest(
         $validation,
-        $shipment,
+        Shipment $shipment,
         ShipmentRequestLabelSpecification $labelSpec = null,
         ShipmentRequestReceiptSpecification $receiptSpec = null
     ) {
@@ -128,8 +133,8 @@ class Shipping extends Ups
         // Page 47
         $shipmentNode = $container->appendChild($xml->createElement('Shipment'));
 
-        if (isset($shipment->Description)) {
-            $shipmentNode->appendChild($xml->createElement('Description', $shipment->Description));
+        if ($shipment->getDescription()) {
+            $shipmentNode->appendChild($xml->createElement('Description', $shipment->getDescription()));
         }
 
         $returnService = $shipment->getReturnService();
@@ -145,110 +150,107 @@ class Shipping extends Ups
 
         $shipperNode = $shipmentNode->appendChild($xml->createElement('Shipper'));
 
-        $shipperNode->appendChild($xml->createElement('Name', $shipment->Shipper->Name));
+        $shipperNode->appendChild($xml->createElement('Name', $shipment->getShipper()->getName()));
 
-        if (isset($shipment->Shipper->AttentionName)) {
-            $shipperNode->appendChild($xml->createElement('AttentionName', $shipment->Shipper->AttentionName));
+        if ($shipment->getShipper()->getAttentionName()) {
+            $shipperNode->appendChild($xml->createElement('AttentionName', $shipment->getShipper()->getAttentionName()));
         }
 
-        if (isset($shipment->Shipper->CompanyDisplayableName)) {
-            $shipperNode->appendChild($xml->createElement('CompanyDisplayableName', $shipment->Shipper->CompanyDisplayableName));
+        if ($shipment->getShipper()->getCompanyName()) {
+            $shipperNode->appendChild($xml->createElement('CompanyDisplayableName', $shipment->getShipper()->getCompanyName()));
         }
 
-        $shipperNode->appendChild($xml->createElement('ShipperNumber', $shipment->Shipper->ShipperNumber));
+        $shipperNode->appendChild($xml->createElement('ShipperNumber', $shipment->getShipper()->getShipperNumber()));
 
-        if (isset($shipment->Shipper->TaxIdentificationNumber)) {
-            $shipperNode->appendChild($xml->createElement('TaxIdentificationNumber', $shipment->Shipper->TaxIdentificationNumber));
+        if ($shipment->getShipper()->getTaxIdentificationNumber()) {
+            $shipperNode->appendChild($xml->createElement('TaxIdentificationNumber', $shipment->getShipper()->getTaxIdentificationNumber()));
         }
 
-        if (isset($shipment->Shipper->PhoneNumber)) {
-            $shipperNode->appendChild($xml->createElement('PhoneNumber', $shipment->Shipper->PhoneNumber));
+        if ($shipment->getShipper()->getPhoneNumber()) {
+            $shipperNode->appendChild($xml->createElement('PhoneNumber', $shipment->getShipper()->getPhoneNumber()));
         }
 
-        if (isset($shipment->Shipper->FaxNumber)) {
-            $shipperNode->appendChild($xml->createElement('FaxNumber', $shipment->Shipper->FaxNumber));
+        if ($shipment->getShipper()->getFaxNumber()) {
+            $shipperNode->appendChild($xml->createElement('FaxNumber', $shipment->getShipper()->getFaxNumber()));
         }
 
-        if (isset($shipment->Shipper->EMailAddress)) {
-            $shipperNode->appendChild($xml->createElement('EMailAddress', $shipment->Shipper->EMailAddress));
+        if ($shipment->getShipper()->getEMailAddress()) {
+            $shipperNode->appendChild($xml->createElement('EMailAddress', $shipment->getShipper()->getEMailAddress()));
         }
 
-        $addressNode = $xml->importNode($this->compileAddressNode($shipment->Shipper->Address), true);
-        $shipperNode->appendChild($addressNode);
+        $shipperNode->appendChild($shipment->getShipper()->getAddress()->toNode($xml));
 
         $shipToNode = $shipmentNode->appendChild($xml->createElement('ShipTo'));
 
-        $shipToNode->appendChild($xml->createElement('CompanyName', $shipment->ShipTo->CompanyName));
+        $shipToNode->appendChild($xml->createElement('CompanyName', $shipment->getShipTo()->getCompanyName()));
 
-        if (isset($shipment->ShipTo->AttentionName)) {
-            $shipToNode->appendChild($xml->createElement('AttentionName', $shipment->ShipTo->AttentionName));
+        if ($shipment->getShipTo()->getAttentionName()) {
+            $shipToNode->appendChild($xml->createElement('AttentionName', $shipment->getShipTo()->getAttentionName()));
         }
 
-        if (isset($shipment->ShipTo->PhoneNumber)) {
-            $shipToNode->appendChild($xml->createElement('PhoneNumber', $shipment->ShipTo->PhoneNumber));
+        if ($shipment->getShipTo()->getPhoneNumber()) {
+            $shipToNode->appendChild($xml->createElement('PhoneNumber', $shipment->getShipTo()->getPhoneNumber()));
         }
 
-        if (isset($shipment->ShipTo->FaxNumber)) {
-            $shipToNode->appendChild($xml->createElement('FaxNumber', $shipment->ShipTo->FaxNumber));
+        if ($shipment->getShipTo()->getFaxNumber()) {
+            $shipToNode->appendChild($xml->createElement('FaxNumber', $shipment->getShipTo()->getFaxNumber()));
         }
 
-        if (isset($shipment->ShipTo->EMailAddress)) {
-            $shipToNode->appendChild($xml->createElement('EMailAddress', $shipment->ShipTo->EMailAddress));
+        if ($shipment->getShipTo()->getEMailAddress()) {
+            $shipToNode->appendChild($xml->createElement('EMailAddress', $shipment->getShipTo()->getEMailAddress()));
         }
 
-        $addressNode = $xml->importNode($this->compileAddressNode($shipment->ShipTo->Address), true);
+        $addressNode = $shipment->getShipTo()->getAddress()->toNode($xml);
 
-        if (isset($shipment->ShipTo->LocationID)) {
-            $addressNode->appendChild($xml->createElement('LocationID', strtoupper($shipment->ShipTo->LocationID)));
+        if ($shipment->getShipTo()->getLocationID()) {
+            $addressNode->appendChild($xml->createElement('LocationID', strtoupper($shipment->getShipTo()->getLocationID())));
         }
 
         $shipToNode->appendChild($addressNode);
 
-        if (isset($shipment->ShipFrom)) {
+        if ($shipment->getShipFrom()) {
             $shipFromNode = $shipmentNode->appendChild($xml->createElement('ShipFrom'));
 
-            $shipFromNode->appendChild($xml->createElement('CompanyName', $shipment->ShipFrom->getCompanyName()));
+            $shipFromNode->appendChild($xml->createElement('CompanyName', $shipment->getShipFrom()->getCompanyName()));
 
-            if (isset($shipment->ShipFrom->AttentionName)) {
-                $shipFromNode->appendChild($xml->createElement('AttentionName', $shipment->ShipFrom->AttentionName));
+            if ($shipment->getShipFrom()->getAttentionName()) {
+                $shipFromNode->appendChild($xml->createElement('AttentionName', $shipment->getShipFrom()->getAttentionName()));
             }
 
-            if (isset($shipment->ShipFrom->PhoneNumber)) {
-                $shipFromNode->appendChild($xml->createElement('PhoneNumber', $shipment->ShipFrom->PhoneNumber));
+            if ($shipment->getShipFrom()->getPhoneNumber()) {
+                $shipFromNode->appendChild($xml->createElement('PhoneNumber', $shipment->getShipFrom()->getPhoneNumber()));
             }
 
-            if (isset($shipment->ShipFrom->FaxNumber)) {
-                $shipFromNode->appendChild($xml->createElement('FaxNumber', $shipment->ShipFrom->FaxNumber));
+            if ($shipment->getShipFrom()->getFaxNumber()) {
+                $shipFromNode->appendChild($xml->createElement('FaxNumber', $shipment->getShipFrom()->getFaxNumber()));
             }
 
-            $addressNode = $xml->importNode($this->compileAddressNode($shipment->ShipFrom->Address), true);
-            $shipFromNode->appendChild($addressNode);
+            $shipFromNode->appendChild($shipment->getShipFrom()->getAddress()->toNode($xml));
         }
 
-        if (isset($shipment->SoldTo)) {
+        if ($shipment->getSoldTo()) {
             $soldToNode = $shipmentNode->appendChild($xml->createElement('SoldTo'));
 
-            if (isset($shipment->SoldTo->Option)) {
-                $soldToNode->appendChild($xml->createElement('Option', $shipment->SoldTo->Option));
+            if ($shipment->getSoldTo()->getOption()) {
+                $soldToNode->appendChild($xml->createElement('Option', $shipment->getSoldTo()->getOption()));
             }
 
-            $soldToNode->appendChild($xml->createElement('CompanyName', $shipment->SoldTo->CompanyName));
+            $soldToNode->appendChild($xml->createElement('CompanyName', $shipment->getSoldTo()->getCompanyName()));
 
-            if (isset($shipment->SoldTo->AttentionName)) {
-                $soldToNode->appendChild($xml->createElement('AttentionName', $shipment->SoldTo->AttentionName));
+            if ($shipment->getSoldTo()->getAttentionName()) {
+                $soldToNode->appendChild($xml->createElement('AttentionName', $shipment->getSoldTo()->getAttentionName()));
             }
 
-            if (isset($shipment->SoldTo->PhoneNumber)) {
-                $soldToNode->appendChild($xml->createElement('PhoneNumber', $shipment->SoldTo->PhoneNumber));
+            if ($shipment->getSoldTo()->getPhoneNumber()) {
+                $soldToNode->appendChild($xml->createElement('PhoneNumber', $shipment->getSoldTo()->getPhoneNumber()));
             }
 
-            if (isset($shipment->SoldTo->FaxNumber)) {
-                $soldToNode->appendChild($xml->createElement('FaxNumber', $shipment->SoldTo->FaxNumber));
+            if ($shipment->getSoldTo()->getFaxNumber()) {
+                $soldToNode->appendChild($xml->createElement('FaxNumber', $shipment->getSoldTo()->getFaxNumber()));
             }
 
-            if (isset($shipment->SoldTo->Address)) {
-                $addressNode = $xml->importNode($this->compileAddressNode($shipment->SoldTo->Address), true);
-                $soldToNode->appendChild($addressNode);
+            if ($shipment->getSoldTo()->getAddress()) {
+                $soldToNode->appendChild($shipment->getSoldTo()->getAddress()->toNode($xml));
             }
         }
 
@@ -257,143 +259,97 @@ class Shipping extends Ups
             $shipmentNode->appendChild($alternate->toNode($xml));
         }
 
-        if (isset($shipment->PaymentInformation)) {
+        if ($shipment->getPaymentInformation()) {
             $paymentNode = $shipmentNode->appendChild($xml->createElement('PaymentInformation'));
 
-            if ($shipment->PaymentInformation->Prepaid) {
+            if ($shipment->getPaymentInformation()->getPrepaid()) {
                 $node = $paymentNode->appendChild($xml->createElement('Prepaid'));
                 $node = $node->appendChild($xml->createElement('BillShipper'));
 
-                if ($shipment->PaymentInformation->Prepaid->BillShipper->AccountNumber) {
-                    $node->appendChild($xml->createElement('AccountNumber', $shipment->PaymentInformation->Prepaid->BillShipper->AccountNumber));
-                } elseif ($shipment->PaymentInformation->Prepaid->BillShipper->CreditCard) {
+                $billShipper = $shipment->getPaymentInformation()->getPrepaid()->getBillShipper();
+                if (isset($billShipper) && $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getAccountNumber()) {
+                    $node->appendChild($xml->createElement('AccountNumber', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getAccountNumber()));
+                } elseif (isset($billShipper) && $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()) {
                     $ccNode = $node->appendChild($xml->createElement('CreditCard'));
-                    $ccNode->appendChild($xml->createElement('Type', $shipment->PaymentInformation->Prepaid->BillShipper->CreditCard->Type));
-                    $ccNode->appendChild($xml->createElement('Number', $shipment->PaymentInformation->Prepaid->BillShipper->CreditCard->Number));
-                    $ccNode->appendChild($xml->createElement('ExpirationDate', $shipment->PaymentInformation->Prepaid->BillShipper->CreditCard->ExpirationDate));
+                    $ccNode->appendChild($xml->createElement('Type', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getType()));
+                    $ccNode->appendChild($xml->createElement('Number', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getNumber()));
+                    $ccNode->appendChild($xml->createElement('ExpirationDate', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getExpirationDate()));
 
-                    if ($shipment->PaymentInformation->Prepaid->BillShipper->CreditCard->SecurityCode) {
-                        $ccNode->appendChild($xml->createElement('SecurityCode', $shipment->PaymentInformation->Prepaid->BillShipper->CreditCard->SecurityCode));
+                    if ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getSecurityCode()) {
+                        $ccNode->appendChild($xml->createElement('SecurityCode', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getSecurityCode()));
                     }
 
-                    if ($shipment->PaymentInformation->Prepaid->BillShipper->CreditCard->Address) {
-                        $addressNode = $xml->importNode($this->compileAddressNode($shipment->PaymentInformation->Prepaid->BillShipper->CreditCard->Address), true);
-                        $ccNode->appendChild($addressNode);
+                    if ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getAddress()) {
+                        $ccNode->appendChild($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getAddress()->toNode($xml));
                     }
                 }
-            } elseif ($shipment->PaymentInformation->BillThirdParty) {
+            } elseif ($shipment->getPaymentInformation()->getBillThirdParty()) {
                 $node = $paymentNode->appendChild($xml->createElement('BillThirdParty'));
                 $btpNode = $node->appendChild($xml->createElement('BillThirdPartyShipper'));
-                $btpNode->appendChild($xml->createElement('AccountNumber', $shipment->PaymentInformation->BillThirdParty->AccountNumber));
+                $btpNode->appendChild($xml->createElement('AccountNumber', $shipment->getPaymentInformation()->getBillThirdParty()->getAccountNumber()));
 
                 $tpNode = $btpNode->appendChild($xml->createElement('ThirdParty'));
                 $addressNode = $tpNode->appendChild($xml->createElement('Address'));
 
-                if ($shipment->PaymentInformation->BillThirdParty->ThirdParty->Address->PostalCode) {
-                    $addressNode->appendChild($xml->createElement('PostalCode', $shipment->PaymentInformation->BillThirdParty->ThirdParty->Address->PostalCode));
+                $thirdPartAddress = $shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress();
+                if (isset($thirdPartAddress) && $shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()) {
+                    $addressNode->appendChild($xml->createElement('PostalCode', $shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()));
                 }
 
-                $addressNode->appendChild($xml->createElement('CountryCode', $shipment->PaymentInformation->BillThirdParty->ThirdParty->Address->CountryCode));
-            } elseif ($shipment->PaymentInformation->FreightCollect) {
+                $addressNode->appendChild($xml->createElement('CountryCode', $shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getCountryCode()));
+            } elseif ($shipment->getPaymentInformation()->getFreightCollect()) {
                 $node = $paymentNode->appendChild($xml->createElement('FreightCollect'));
                 $brNode = $node->appendChild($xml->createElement('BillReceiver'));
-                $brNode->appendChild($xml->createElement('AccountNumber', $shipment->PaymentInformation->FreightCollect->BillReceiver->AccountNumber));
+                $brNode->appendChild($xml->createElement('AccountNumber', $shipment->getPaymentInformation()->getFreightCollect()->getAccountNumber()));
 
-                if ($shipment->PaymentInformation->FreightCollect->BillReceiver->Address) {
+                if ($shipment->getPaymentInformation()->getFreightCollect()->getBillReceiverAddress()) {
                     $addressNode = $brNode->appendChild($xml->createElement('Address'));
-                    $addressNode->appendChild($xml->createElement('PostalCode', $shipment->PaymentInformation->FreightCollect->BillReceiver->Address->PostalCode));
+                    $addressNode->appendChild($xml->createElement('PostalCode', $shipment->getPaymentInformation()->getFreightCollect()->getBillReceiverAddress()->getPostalCode()));
                 }
-            } elseif ($shipment->PaymentInformation->ConsigneeBilled) {
+            } elseif ($shipment->getPaymentInformation()->getConsigneeBilled()) {
                 $paymentNode->appendChild($xml->createElement('ConsigneeBilled'));
             }
-        } elseif (isset($shipment->ItemizedPaymentInformation)) {
-            //$paymentNode = $shipmentNode->appendChild($xml->createElement('ItemizedPaymentInformation'));
+//         TODO: create ItemizedPaymentInformation class and required subclasses for node processing
+//        } elseif ($shipment->getItemizedPaymentInformation()) {
+//            $paymentNode = $shipmentNode->appendChild($xml->createElement('ItemizedPaymentInformation'));
         }
 
-        if (isset($shipment->GoodsNotInFreeCirculationIndicator)) {
+        if ($shipment->getGoodsNotInFreeCirculationIndicator()) {
             $shipmentNode->appendChild($xml->createElement('GoodsNotInFreeCirculationIndicator'));
         }
 
-        if (isset($shipment->MovementReferenceNumber)) {
-            $shipmentNode->appendChild($xml->createElement('MovementReferenceNumber', $shipment->MovementReferenceNumber));
+        if ($shipment->getMovementReferenceNumber()) {
+            $shipmentNode->appendChild($xml->createElement('MovementReferenceNumber', $shipment->getMovementReferenceNumber()));
         }
 
         $serviceNode = $shipmentNode->appendChild($xml->createElement('Service'));
-        $serviceNode->appendChild($xml->createElement('Code', $shipment->Service->getCode()));
+        $serviceNode->appendChild($xml->createElement('Code', $shipment->getService()->getCode()));
 
-        if (isset($shipment->Service->Description)) {
-            $serviceNode->appendChild($xml->createElement('Description', $shipment->Service->Description));
+        if ($shipment->getService()->getDescription()) {
+            $serviceNode->appendChild($xml->createElement('Description', $shipment->getService()->getDescription()));
         }
 
-        if (isset($shipment->InvoiceLineTotal)) {
+        if ($shipment->getInvoiceLineTotal()) {
             $node = $shipmentNode->appendChild($xml->createElement('InvoiceLineTotal'));
 
-            if ($shipment->InvoiceLineTotal->CurrencyCode) {
-                $node->appendChild($xml->createElement('CurrencyCode', $shipment->InvoiceLineTotal->CurrencyCode));
+            if ($shipment->getInvoiceLineTotal()->getCurrencyCode()) {
+                $node->appendChild($xml->createElement('CurrencyCode', $shipment->getInvoiceLineTotal()->getCurrencyCode()));
             }
 
-            $node->appendChild($xml->createElement('MonetaryValue', $shipment->InvoiceLineTotal->MonetaryValue));
+            $node->appendChild($xml->createElement('MonetaryValue', $shipment->getInvoiceLineTotal()->getMonetaryValue()));
         }
 
-        if (isset($shipment->NumOfPiecesInShipment)) {
-            $shipmentNode->appendChild($xml->createElement('NumOfPiecesInShipment', $shipment->NumOfPiecesInShipment));
+        if ($shipment->getNumOfPiecesInShipment()) {
+            $shipmentNode->appendChild($xml->createElement('NumOfPiecesInShipment', $shipment->getNumOfPiecesInShipment()));
         }
 
-        if (isset($shipment->RateInformation)) {
+        if ($shipment->getRateInformation()) {
             $node = $shipmentNode->appendChild($xml->createElement('RateInformation'));
             $node->appendChild($xml->createElement('NegotiatedRatesIndicator'));
         }
 
         foreach ($shipment->getPackages() as &$package) {
-            $node = $shipmentNode->appendChild($xml->createElement('Package'));
-
-            if (isset($package->Description)) {
-                $node->appendChild($xml->createElement('Description', $package->Description));
-            }
-
-            $ptNode = $node->appendChild($xml->createElement('PackagingType'));
-            $ptNode->appendChild($xml->createElement('Code', $package->PackagingType->Code));
-
-            if (isset($package->PackagingType->Description)) {
-                $ptNode->appendChild($xml->createElement('Description', $package->PackagingType->Description));
-            }
-
-            $pwNode = $node->appendChild($xml->createElement('PackageWeight'));
-            $umNode = $pwNode->appendChild($xml->createElement('UnitOfMeasurement'));
-
-            if (isset($package->PackageWeight->UnitOfMeasurement->Code)) {
-                $umNode->appendChild($xml->createElement('Code', $package->PackageWeight->UnitOfMeasurement->Code));
-            }
-
-            if (isset($package->PackageWeight->UnitOfMeasurement->Description)) {
-                $umNode->appendChild($xml->createElement('Description', $package->PackageWeight->UnitOfMeasurement->Description));
-            }
-
-            $dimensions = $package->getDimensions();
-            if (isset($dimensions)) {
-                $node->appendChild($dimensions->toNode($xml));
-            }
-
-            $pwNode->appendChild($xml->createElement('Weight', $package->PackageWeight->Weight));
-
-            if (isset($package->LargePackageIndicator)) {
-                $node->appendChild($xml->createElement('LargePackageIndicator'));
-            }
-
-            if (isset($package->ReferenceNumber) && isset($package->ReferenceNumber->Code) && isset($package->ReferenceNumber->Value)) {
-                $refNode = $node->appendChild($xml->createElement('ReferenceNumber'));
-
-                if ($package->ReferenceNumber->BarCodeIndicator) {
-                    $refNode->appendChild($xml->createElement('BarCodeIndicator', $package->ReferenceNumber->BarCodeIndicator));
-                }
-
-                $refNode->appendChild($xml->createElement('Code', $package->ReferenceNumber->Code));
-                $refNode->appendChild($xml->createElement('Value', $package->ReferenceNumber->Value));
-            }
-
-            if (isset($package->AdditionalHandling)) {
-                $refNode->appendChild($xml->createElement('AdditionalHandling'));
-            }
+            $shipmentNode->appendChild($xml->importNode($package->toNode($xml), true));
         }
 
         $shipmentServiceOptions = $shipment->getShipmentServiceOptions();
@@ -407,43 +363,7 @@ class Shipping extends Ups
         }
 
         if ($labelSpec) {
-            $labelSpecNode = $container->appendChild($xml->createElement('LabelSpecification'));
-
-            $printMethodNode = $labelSpecNode->appendChild($xml->createElement('LabelPrintMethod'));
-            $printMethodNode->appendChild($xml->createElement('Code', $labelSpec->getPrintMethodCode()));
-
-            if ($labelSpec->getPrintMethodDescription()) {
-                $printMethodNode->appendChild($xml->createElement('Description', $labelSpec->getPrintMethodDescription()));
-            }
-
-            if ($labelSpec->getHttpUserAgent()) {
-                $labelSpecNode->appendChild($xml->createElement('HTTPUserAgent', $labelSpec->getHttpUserAgent()));
-            }
-
-            //Label print method is required only for GIF label formats
-            if ($labelSpec->getPrintMethodCode() == ShipmentRequestLabelSpecification::IMG_FORMAT_CODE_GIF) {
-                $imageFormatNode = $labelSpecNode->appendChild($xml->createElement('LabelImageFormat'));
-                $imageFormatNode->appendChild($xml->createElement('Code', $labelSpec->getImageFormatCode()));
-
-                if ($labelSpec->getImageFormatDescription()) {
-                    $imageFormatNode->appendChild($xml->createElement('Description', $labelSpec->getImageFormatDescription()));
-                }
-            } else {
-                //Label stock size is required only for non-GIF label formats
-                $stockSizeNode = $labelSpecNode->appendChild($xml->createElement('LabelStockSize'));
-
-                $stockSizeNode->appendChild($xml->createElement('Height', $labelSpec->getStockSizeHeight()));
-                $stockSizeNode->appendChild($xml->createElement('Width', $labelSpec->getStockSizeWidth()));
-            }
-
-            if (isset($labelSpec->Instruction)) {
-                $instructionNode = $labelSpecNode->appendChild($xml->createElement('Instruction'));
-                $instructionNode->appendChild($xml->createElement('Code', $labelSpec->getInstructionCode()));
-
-                if ($labelSpec->Instruction->Description) {
-                    $instructionNode->appendChild($xml->createElement('Description', $labelSpec->getInstructionDescription()));
-                }
-            }
+            $container->appendChild($xml->importNode($this->compileLabelSpecificationNode($labelSpec), true));
         }
 
         $shipmentIndicationType = $shipment->getShipmentIndicationType();
@@ -452,13 +372,7 @@ class Shipping extends Ups
         }
 
         if ($receiptSpec) {
-            $receiptSpecNode = $container->appendChild($xml->createElement('ReceiptSpecification'));
-            $imageFormatNode = $receiptSpecNode->appendChild($xml->createElement('ImageFormat'));
-            $imageFormatNode->appendChild($xml->createElement('Code', $receiptSpec->getImageFormatCode()));
-
-            if ($receiptSpec->getImageFormatDescription()) {
-                $imageFormatNode->appendChild($xml->createElement('Description', $receiptSpec->getImageFormatDescription()));
-            }
+            $container->appendChild($xml->importNode($this->compileReceiptSpecificationNode($receiptSpec), true));
         }
 
         return $xml->saveXML();
@@ -700,51 +614,6 @@ class Shipping extends Ups
     }
 
     /**
-     * Generates a standard <Address> node for requests.
-     *
-     * @param stdClass $address Address data structure
-     *
-     * @return SimpleXMLElement
-     */
-    private function compileAddressNode(&$address)
-    {
-        $xml = new DOMDocument();
-        $xml->formatOutput = true;
-
-        $node = $xml->appendChild($xml->createElement('Address'));
-
-        $node->appendChild($xml->createElement('AddressLine1', $address->AddressLine1));
-
-        if (isset($address->AddressLine2)) {
-            $node->appendChild($xml->createElement('AddressLine2', $address->AddressLine2));
-        }
-
-        if (isset($address->AddressLine3)) {
-            $node->appendChild($xml->createElement('AddressLine3', $address->AddressLine3));
-        }
-
-        $node->appendChild($xml->createElement('City', $address->City));
-
-        if (isset($address->StateProvinceCode)) {
-            $node->appendChild($xml->createElement('StateProvinceCode', $address->StateProvinceCode));
-        }
-
-        if (isset($address->PostalCode)) {
-            $node->appendChild($xml->createElement('PostalCode', $address->PostalCode));
-        }
-
-        if (isset($address->CountryCode)) {
-            $node->appendChild($xml->createElement('CountryCode', $address->CountryCode));
-        }
-
-        if (isset($address->ResidentialAddressIndicator)) {
-            $node->appendChild($xml->createElement('ResidentialAddress'));
-        }
-
-        return $node->cloneNode(true);
-    }
-
-    /**
      * @return RequestInterface
      */
     public function getRequest()
@@ -786,5 +655,76 @@ class Shipping extends Ups
         $this->response = $response;
 
         return $this;
+    }
+
+    /**
+     * @param ShipmentRequestReceiptSpecification $receiptSpec
+     * @return DOMNode
+     */
+    private function compileReceiptSpecificationNode(ShipmentRequestReceiptSpecification $receiptSpec)
+    {
+        $xml = new DOMDocument();
+        $xml->formatOutput = true;
+
+        $receiptSpecNode = $xml->appendChild($xml->createElement('ReceiptSpecification'));
+
+        $imageFormatNode = $receiptSpecNode->appendChild($xml->createElement('ImageFormat'));
+        $imageFormatNode->appendChild($xml->createElement('Code', $receiptSpec->getImageFormatCode()));
+
+        if ($receiptSpec->getImageFormatDescription()) {
+            $imageFormatNode->appendChild($xml->createElement('Description', $receiptSpec->getImageFormatDescription()));
+        }
+
+        return $receiptSpecNode->cloneNode(true);
+    }
+
+    /**
+     * @param ShipmentRequestLabelSpecification $labelSpec
+     * @return DOMNode
+     */
+    private function compileLabelSpecificationNode(ShipmentRequestLabelSpecification $labelSpec)
+    {
+        $xml = new DOMDocument();
+        $xml->formatOutput = true;
+
+        $labelSpecNode = $xml->appendChild($xml->createElement('LabelSpecification'));
+
+        $printMethodNode = $labelSpecNode->appendChild($xml->createElement('LabelPrintMethod'));
+        $printMethodNode->appendChild($xml->createElement('Code', $labelSpec->getPrintMethodCode()));
+
+        if ($labelSpec->getPrintMethodDescription()) {
+            $printMethodNode->appendChild($xml->createElement('Description', $labelSpec->getPrintMethodDescription()));
+        }
+
+        if ($labelSpec->getHttpUserAgent()) {
+            $labelSpecNode->appendChild($xml->createElement('HTTPUserAgent', $labelSpec->getHttpUserAgent()));
+        }
+
+        //Label print method is required only for GIF label formats
+        if ($labelSpec->getPrintMethodCode() == ShipmentRequestLabelSpecification::IMG_FORMAT_CODE_GIF) {
+            $imageFormatNode = $labelSpecNode->appendChild($xml->createElement('LabelImageFormat'));
+            $imageFormatNode->appendChild($xml->createElement('Code', $labelSpec->getImageFormatCode()));
+
+            if ($labelSpec->getImageFormatDescription()) {
+                $imageFormatNode->appendChild($xml->createElement('Description', $labelSpec->getImageFormatDescription()));
+            }
+        } else {
+            //Label stock size is required only for non-GIF label formats
+            $stockSizeNode = $labelSpecNode->appendChild($xml->createElement('LabelStockSize'));
+
+            $stockSizeNode->appendChild($xml->createElement('Height', $labelSpec->getStockSizeHeight()));
+            $stockSizeNode->appendChild($xml->createElement('Width', $labelSpec->getStockSizeWidth()));
+        }
+
+        if ($labelSpec->getInstructionCode()) {
+            $instructionNode = $labelSpecNode->appendChild($xml->createElement('Instruction'));
+            $instructionNode->appendChild($xml->createElement('Code', $labelSpec->getInstructionCode()));
+
+            if ($labelSpec->getInstructionDescription()) {
+                $instructionNode->appendChild($xml->createElement('Description', $labelSpec->getInstructionDescription()));
+            }
+        }
+
+        return $labelSpecNode->cloneNode(true);
     }
 }


### PR DESCRIPTION
This mainly makes use of getter/setter methods instead of public object parameters in Shipping class.
`compileAddressNode` was removed and some code was deleted in favor of broader usage of `toNode()` methods.
Added ShipmentRequestLabelSpecification and ShipmentRequestReceiptSpecification classes for easier options passing.