### PR TITLE
Make sure ShipFrom is not created by default and can be set to null

### DIFF
--- a/src/Entity/Shipment.php
+++ b/src/Entity/Shipment.php
@@ -102,7 +102,6 @@ class Shipment
     public function __construct()
     {
         $this->setShipper(new Shipper());
-        $this->setShipFrom(new ShipFrom());
         $this->setShipTo(new ShipTo());
         $this->setShipmentServiceOptions(new ShipmentServiceOptions());
         $this->setService(new Service());


### PR DESCRIPTION
Ship From is an optional node (which is required only if Shipper differs from location from which package to be shipped) so it should not be created by default and should be 'nullable'.