### PR TITLE
Adds support for a second reference number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.7.1 (released 23-11-2015)
+
+- Adds support for a second reference number
+
 ## 0.7.0 (released 16-11-2015)
 
 - **[!]** Default ShipFrom on Shipment class not set anymore in constructor (ShipFrom is optional)

--- a/src/Entity/Shipment.php
+++ b/src/Entity/Shipment.php
@@ -70,9 +70,9 @@ class Shipment
     private $packages = [];
 
     /**
-     * @var ReferenceNumber
+     * @var ReferenceNumber[]
      */
-    private $referenceNumber;
+    private $referenceNumbers = [];
 
     /**
      * @var ShipmentServiceOptions
@@ -175,13 +175,27 @@ class Shipment
     }
 
     /**
-     * @param ReferenceNumber $referenceNumber
+     * @param Package $package
      *
      * @return Shipment
      */
-    public function setReferenceNumber(ReferenceNumber $referenceNumber)
+    public function addReferenceNumber(ReferenceNumber $referenceNumber)
     {
-        $this->referenceNumber = $referenceNumber;
+        $referenceNumbers = $this->getReferenceNumbers();
+        $referenceNumbers[] = $referenceNumber;
+        $this->setReferenceNumbers($referenceNumbers);
+
+        return $this;
+    }
+
+    /**
+     * @param ReferenceNumber $referenceNumbers
+     *
+     * @return Shipment
+     */
+    public function setReferenceNumbers(array $referenceNumbers)
+    {
+        $this->referenceNumbers = $referenceNumbers;
 
         return $this;
     }
@@ -189,9 +203,9 @@ class Shipment
     /**
      * @return ReferenceNumber
      */
-    public function getReferenceNumber()
+    public function getReferenceNumbers()
     {
-        return $this->referenceNumber;
+        return $this->referenceNumbers;
     }
 
     /**

--- a/src/Entity/Shipment.php
+++ b/src/Entity/Shipment.php
@@ -70,9 +70,14 @@ class Shipment
     private $packages = [];
 
     /**
-     * @var ReferenceNumber[]
+     * @var ReferenceNumber
      */
-    private $referenceNumbers = [];
+    private $referenceNumber;
+    
+    /**
+     * @var ReferenceNumber
+     */
+    private $referenceNumber2;
 
     /**
      * @var ShipmentServiceOptions
@@ -175,27 +180,25 @@ class Shipment
     }
 
     /**
-     * @param Package $package
+     * @param ReferenceNumber $referenceNumber
      *
      * @return Shipment
      */
-    public function addReferenceNumber(ReferenceNumber $referenceNumber)
+    public function setReferenceNumber(ReferenceNumber $referenceNumber)
     {
-        $referenceNumbers = $this->getReferenceNumbers();
-        $referenceNumbers[] = $referenceNumber;
-        $this->setReferenceNumbers($referenceNumbers);
+        $this->referenceNumber = $referenceNumber;
 
         return $this;
     }
-
+    
     /**
-     * @param ReferenceNumber $referenceNumbers
+     * @param ReferenceNumber $referenceNumber
      *
      * @return Shipment
      */
-    public function setReferenceNumbers(array $referenceNumbers)
+    public function setReferenceNumber2(ReferenceNumber $referenceNumber)
     {
-        $this->referenceNumbers = $referenceNumbers;
+        $this->referenceNumber2 = $referenceNumber;
 
         return $this;
     }
@@ -203,9 +206,17 @@ class Shipment
     /**
      * @return ReferenceNumber
      */
-    public function getReferenceNumbers()
+    public function getReferenceNumber()
     {
-        return $this->referenceNumbers;
+        return $this->referenceNumber;
+    }
+    
+    /**
+     * @return ReferenceNumber
+     */
+    public function getReferenceNumber2()
+    {
+        return $this->referenceNumber2;
     }
 
     /**

--- a/src/Shipping.php
+++ b/src/Shipping.php
@@ -351,11 +351,14 @@ class Shipping extends Ups
             $shipmentNode->appendChild($shipmentServiceOptions->toNode($xml));
         }
 
-        $referenceNumbers = $shipment->getReferenceNumbers();
-        if (isset($referenceNumbers)) {
-            foreach($referenceNumbers as $referenceNumber) {
-                $shipmentNode->appendChild($referenceNumber->toNode($xml));
-            }
+        $referenceNumber = $shipment->getReferenceNumber();
+        if (isset($referenceNumber)) {
+            $shipmentNode->appendChild($referenceNumber->toNode($xml));
+        }
+        
+        $referenceNumber2 = $shipment->getReferenceNumber2();
+        if (isset($referenceNumber2)) {
+            $shipmentNode->appendChild($referenceNumber2->toNode($xml));
         }
 
         if ($labelSpec) {

--- a/src/Shipping.php
+++ b/src/Shipping.php
@@ -351,9 +351,11 @@ class Shipping extends Ups
             $shipmentNode->appendChild($shipmentServiceOptions->toNode($xml));
         }
 
-        $referenceNumber = $shipment->getReferenceNumber();
-        if (isset($referenceNumber)) {
-            $shipmentNode->appendChild($referenceNumber->toNode($xml));
+        $referenceNumbers = $shipment->getReferenceNumbers();
+        if (isset($referenceNumbers)) {
+            foreach($referenceNumbers as $referenceNumber) {
+                $shipmentNode->appendChild($referenceNumber->toNode($xml));
+            }
         }
 
         if ($labelSpec) {


### PR DESCRIPTION
The UPS API allows to set two different reference numbers for a shipment. This functionality is added with this pull request.