### PR TITLE
Fix XML node names

### DIFF
--- a/src/AddressValidation.php
+++ b/src/AddressValidation.php
@@ -188,11 +188,11 @@ class AddressValidation extends Ups
                 $addressNode->appendChild($xml->createElement('AddressLine', $this->address->getAddressLine3()));
             }
             if ($this->address->getStateProvinceCode()) {
-                $addressNode->appendChild($xml->createElement('PoliticalDivision2',
+                $addressNode->appendChild($xml->createElement('PoliticalDivision1',
                     $this->address->getStateProvinceCode()));
             }
             if ($this->address->getCity()) {
-                $addressNode->appendChild($xml->createElement('PoliticalDivision1', $this->address->getCity()));
+                $addressNode->appendChild($xml->createElement('PoliticalDivision2', $this->address->getCity()));
             }
             if ($this->address->getCountryCode()) {
                 $addressNode->appendChild($xml->createElement('CountryCode', $this->address->getCountryCode()));

--- a/tests/Ups/Tests/_files/requests/AddressValidation/Request1.xml
+++ b/tests/Ups/Tests/_files/requests/AddressValidation/Request1.xml
@@ -12,8 +12,8 @@
         <AddressLine>Times Square 1</AddressLine>
         <AddressLine>First Corner</AddressLine>
         <AddressLine>Second Corner</AddressLine>
-        <PoliticalDivision2>NY</PoliticalDivision2>
-        <PoliticalDivision1>New York</PoliticalDivision1>
+        <PoliticalDivision2>New York</PoliticalDivision2>
+        <PoliticalDivision1>NY</PoliticalDivision1>
         <CountryCode>US</CountryCode>
         <PostcodePrimaryLow>50000</PostcodePrimaryLow>
     </AddressKeyFormat>


### PR DESCRIPTION
Fixed the flip-flopped use of PoliticalDivision1 & 2 for city & state/province, referenced in issue #85 