### PR TITLE
Adjusts Tracking API, adds new attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,34 @@ Tracking parameters are:
  * `referenceNumber` The ability to track any UPS package or shipment by reference number. Reference numbers can be a purchase order number, job number, etc. Reference Number is supplied when generating a shipment.
  * `requestOption` Optional processing. For Mail Innovations the only valid options are Last Activity and All activity.
 
+<a name="tracking-class-example"></a>
+### Example using Reference Number with additional parameters
+
+```php
+$tracking = new Ups\Tracking($accessKey, $userId, $password);
+
+$tracking->setShipperNumber('SHIPPER NUMBER');
+
+$beginDate = new \DateTime('2016-01-01');
+$endDate = new \DateTime('2016-01-31');
+
+$tracking->setBeginDate($beginDate);
+$tracking->setEndDate($endDate);
+
+try {
+    $shipment = $tracking->trackByReference('REFERENCE NUMBER');
+
+    foreach($shipment->Package->Activity as $activity) {
+        var_dump($activity);
+    }
+
+} catch (Exception $e) {
+    var_dump($e);
+}
+```
+
+The parameters shipperNumber, beginDate and endDate are optional. Either of the parameters can be set individually. These parameters can help to narrow the search field when tracking by reference, since it might happen that the reference number used is not unique. When using tracking by tracking number these parameters are not needed since the tracking number is unique.
+
 <a name="rate-class"></a>
 ## Rate Class
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -7,7 +7,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 use stdClass;
-
+use DateTime;
 /**
  * Tracking API Wrapper.
  */
@@ -159,7 +159,7 @@ class Tracking extends Ups
      * @param string $beginDate
      *
      */
-    public function setBeginDate($beginDate)
+    public function setBeginDate(DateTime $beginDate)
     {
         $this->beginDate = $beginDate;
     }
@@ -170,7 +170,7 @@ class Tracking extends Ups
      * @param string $endDate
      *
      */
-    public function setEndDate($endDate)
+    public function setEndDate(DateTime $endDate)
     {
         $this->endDate = $endDate;
     }
@@ -275,11 +275,13 @@ class Tracking extends Ups
         }
 
         if (null !== $this->beginDate) {
-            $trackRequest->appendChild($xml->createElement('BeginDate', $this->beginDate));
+            $beginDate = $this->beginDate->format('Ymd');
+            $trackRequest->appendChild($xml->createElement('BeginDate', $beginDate));
         }
 
         if (null !== $this->endDate) {
-            $trackRequest->appendChild($xml->createElement('EndDate', $this->endDate));
+            $endDate = $this->endDate->format('Ymd');
+            $trackRequest->appendChild($xml->createElement('EndDate', $endDate));
         }
 
         return $xml->saveXML();

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -42,6 +42,21 @@ class Tracking extends Ups
     private $requestOption;
 
     /**
+     * @var string
+     */
+    private $shipperNumber;
+
+    /**
+     * @var string
+     */
+    private $beginDate;
+
+    /**
+     * @var string
+     */
+    private $endDate;
+
+    /**
      * @param string|null $accessKey UPS License Access Key
      * @param string|null $userId UPS User ID
      * @param string|null $password UPS User Password
@@ -125,6 +140,39 @@ class Tracking extends Ups
         } else {
             return $this->formatResponse($response);
         }
+    }
+
+    /**
+     * Set shipper number
+     *
+     * @param string $shipperNumber
+     *
+     */
+    public function setShipperNumber($shipperNumber)
+    {
+        $this->shipperNumber = $shipperNumber;
+    }
+
+    /**
+     * Set begin date
+     *
+     * @param string $beginDate
+     *
+     */
+    public function setBeginDate($beginDate)
+    {
+        $this->beginDate = $beginDate;
+    }
+
+    /**
+     * Set end date
+     *
+     * @param string $endDate
+     *
+     */
+    public function setEndDate($endDate)
+    {
+        $this->endDate = $endDate;
     }
 
     /**
@@ -221,6 +269,19 @@ class Tracking extends Ups
         if (null !== $this->referenceNumber) {
             $trackRequest->appendChild($xml->createElement('ReferenceNumber'))->appendChild($xml->createElement('Value', $this->referenceNumber));
         }
+
+        if (null !== $this->shipperNumber) {
+            $trackRequest->appendChild($xml->createElement('ShipperNumber', $this->shipperNumber));
+        }
+
+        if (null !== $this->beginDate) {
+            $trackRequest->appendChild($xml->createElement('BeginDate', $this->beginDate));
+        }
+
+        if (null !== $this->endDate) {
+            $trackRequest->appendChild($xml->createElement('EndDate', $this->endDate));
+        }
+
         return $xml->saveXML();
     }
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -48,12 +48,12 @@ class Tracking extends Ups
     private $shipperNumber;
 
     /**
-     * @var string
+     * @var \DateTime
      */
     private $beginDate;
 
     /**
-     * @var string
+     * @var \DateTime
      */
     private $endDate;
 

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -8,6 +8,7 @@ use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 use stdClass;
 use DateTime;
+
 /**
  * Tracking API Wrapper.
  */


### PR DESCRIPTION
If the referenceNumber is not unique, trackingByReference is not working. Thus it is necessary to narrow the search field. Added attributes: shipperNumber, beginDate, endDate.

Sorry for creating two pull requests, missed to update before I commited the changes.