### PR TITLE
Do not create new Guzzle object on each Request

### DIFF
--- a/src/Entity/AccessPointCOD.php
+++ b/src/Entity/AccessPointCOD.php
@@ -73,5 +73,4 @@ class AccessPointCOD implements NodeInterface
     {
         $this->monetaryValue = $monetaryValue;
     }
-
 }

--- a/src/Entity/COD.php
+++ b/src/Entity/COD.php
@@ -8,7 +8,6 @@ use Ups\NodeInterface;
 
 class COD implements NodeInterface
 {
-
     public $CODCode;
     public $CODFundsCode;
     public $CODAmount;

--- a/src/Entity/Tradeability/FreightCharges.php
+++ b/src/Entity/Tradeability/FreightCharges.php
@@ -7,7 +7,6 @@ use DOMElement;
 
 class FreightCharges extends \Ups\Entity\FreightCharges
 {
-
     private $currencyCode;
 
     public function __construct($response = null)

--- a/src/Entity/Tradeability/Shipment.php
+++ b/src/Entity/Tradeability/Shipment.php
@@ -9,7 +9,6 @@ use Ups\NodeInterface;
 
 class Shipment implements NodeInterface
 {
-
     const TRANSPORT_MODE_AIR = 1;
     const TRANSPORT_MODE_GROUND = 2;
     const TRANSPORT_MODE_RAIL = 3;

--- a/src/Request.php
+++ b/src/Request.php
@@ -35,6 +35,11 @@ class Request implements RequestInterface, LoggerAwareInterface
     protected $logger;
 
     /**
+     * @var Guzzle
+     */
+    protected $client;
+
+    /**
      * @param LoggerInterface $logger
      */
     public function __construct(LoggerInterface $logger = null)
@@ -44,6 +49,8 @@ class Request implements RequestInterface, LoggerAwareInterface
         } else {
             $this->setLogger(new NullLogger);
         }
+
+        $this->setClient();
     }
 
     /**
@@ -56,6 +63,16 @@ class Request implements RequestInterface, LoggerAwareInterface
     public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+    }
+
+    /**
+     * Creates a single instance of the Guzzle client
+     *
+     * @return null
+     */
+    public function setClient()
+    {
+        $this->client = new Guzzle();
     }
 
     /**
@@ -90,9 +107,7 @@ class Request implements RequestInterface, LoggerAwareInterface
         ]);
 
         try {
-            $client = new Guzzle();
-
-            $response = $client->post(
+            $response = $this->client->post(
                 $this->getEndpointUrl(),
                 [
                     'body' => $this->getAccess() . $this->getRequest(),

--- a/tests/Ups/Tests/TrackingMITest.php
+++ b/tests/Ups/Tests/TrackingMITest.php
@@ -8,7 +8,6 @@ use Ups;
 
 class TrackingMITest extends PHPUnit_Framework_TestCase
 {
-
     public function testCreateRequest()
     {
         $tracking = new Ups\Tracking();

--- a/tests/Ups/Tests/TradeabilityTest.php
+++ b/tests/Ups/Tests/TradeabilityTest.php
@@ -8,7 +8,6 @@ use Ups;
 
 class TradeabilityTest extends PHPUnit_Framework_TestCase
 {
-
     public function testCreateRequest()
     {
         $api = new Ups\Tradeability();


### PR DESCRIPTION
After a couple hundred calls, this chokes. In our application we use a cron to check Tracking Activity on a large number of orders periodically. Creating a new instance of Guzzle for each request eventually throws an error.

Failure: cURL error 35: error:02001018:system library:fopen:Too many open files (see http://curl.haxx.se/libcurl/c/libcurl-errors.html) 149:/gabrielbull/ups-api/src/Request.php