### PR TITLE
Add Customer Classification

### DIFF
--- a/src/Entity/CustomerClassification.php
+++ b/src/Entity/CustomerClassification.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Ups\Entity;
+
+use DOMDocument;
+use DOMElement;
+use Ups\NodeInterface;
+
+class CustomerClassification implements NodeInterface
+{
+    const RT_SHIPPER  = '00';
+    const RT_DAILY    = '01';
+    const RT_RETAIL   = '04';
+    const RT_REGIONAL = '05';
+    const RT_GENLIST  = '06';
+    const RT_STDLIST  = '53';
+
+    /**
+     * @var string
+     */
+    private $code;
+
+    /**
+     * @param null|DOMDocument $document
+     *
+     * @return DOMElement
+     */
+    public function toNode(DOMDocument $document = null)
+    {
+        if (null === $document) {
+            $document = new DOMDocument();
+        }
+
+        $node = $document->createElement('CustomerClassification');
+        $node->appendChild($document->createElement('Code', $this->getCode()));
+
+        return $node;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return $this
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+}

--- a/src/Entity/RateRequest.php
+++ b/src/Entity/RateRequest.php
@@ -15,6 +15,11 @@ class RateRequest
     private $pickupType;
 
     /**
+     * @var CustomerClassification
+     */
+    private $customerClassification;
+
+    /**
      * @var Shipment
      */
     private $shipment;
@@ -45,6 +50,26 @@ class RateRequest
     {
         $this->PickupType = $pickupType;
         $this->pickupType = $pickupType;
+
+        return $this;
+    }
+
+    /**
+     * @return CustomerClassification
+     */
+    public function getCustomerClassification()
+    {
+        return $this->customerClassification;
+    }
+
+    /**
+     * @param CustomerClassification $customerClassification
+     *
+     * @return $this
+     */
+    public function setCustomerClassification(CustomerClassification $customerClassification)
+    {
+        $this->customerClassification = $customerClassification;
 
         return $this;
     }

--- a/src/Rate.php
+++ b/src/Rate.php
@@ -136,6 +136,11 @@ class Rate extends Ups
 
         $trackRequest->appendChild($rateRequest->getPickupType()->toNode($document));
 
+        $customerClassification = $rateRequest->getCustomerClassification();
+        if (isset($customerClassification)) {
+            $trackRequest->appendChild($customerClassification->toNode($document));
+        }
+
         $shipmentNode = $trackRequest->appendChild($xml->createElement('Shipment'));
 
         // Support specifying an individual service


### PR DESCRIPTION
This is a missing section in the RateRequest API wrapper. The CustomerClassification node is valid only when the ShipFrom country is US, and determines which rate to return with the request.

The CustomerClassification node is NOT automatically added to the /RatingServiceSelectionRequest XML like PickupType and Shipment because it has default behavior if it is not included. Per the UPS API documents: "If customer classification code is not provided or it is provided with an invalid value, UPS would use rate chart (customer classification code) associated with a shipper country to rate the shipments."

All valid Customer Classification codes are labeled as constants with prefix RT_, and are listed in CustomerClassification.php.