### PR TITLE
TimeInTransit Service Codes, InternationalForms EEIFilingOption & AdditionalDocumentIndicator, StatusType Constants, Unit Bug Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.7.9 (released 01-07-2016)
+
+- Add Shipping API Support for AdditionalDocumentIndicator in the InternationalForms node
+- Add Shipping API Support for EEIFilingOption in the InternationalForms node
+- Add TimeInTransit API Response Service Code Constants for US/EU Shipments to Entity/Service.php
+- Add Tracking API Response StatusType Constants
+
 ## 0.7.8 (released 23-06-2016)
 
 - Do not create new Guzzle object instance on each Request, but re-use it. 

--- a/src/Entity/EEIFilingOption.php
+++ b/src/Entity/EEIFilingOption.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Ups\Entity;
+
+use DOMDocument;
+use DOMElement;
+use Ups\NodeInterface;
+
+class EEIFilingOption implements NodeInterface
+{
+    const FO_SHIPPER = '1';  // Shipper Filed
+    const FO_UPS     = '3';  // UPS Filed
+
+    /**
+     * @var string
+     */
+    private $code;
+
+    /**
+     * @var string
+     */
+    private $emailAddress;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @var UPSFiled
+     */
+    private $upsFiled;
+
+    /**
+     * @var ShipperFiled
+     */
+    private $shipperFiled;
+
+    /**
+     * @param null|object $attributes
+     */
+    public function __construct($attributes = null)
+    {
+        if (null !== $attributes) {
+            if (isset($attributes->Code)) {
+                $this->setCode($attributes->Code);
+            }
+            if (isset($attributes->EmailAddress)) {
+                $this->setEmailAddress($attributes->EmailAddress);
+            }
+            if (isset($attributes->Description)) {
+                $this->setDescription($attributes->Description);
+            }
+            if (isset($attributes->UPSFiled)) {
+                $this->setUPSFiled(new UPSFiled($attributes->UPSFiled));
+            }
+            if (isset($attributes->ShipperFiled)) {
+                $this->setShipperFiled(new ShipperFiled($attributes->ShipperFiled));
+            }
+        }
+    }
+
+    /**
+     * @param null|DOMDocument $document
+     *
+     * @return DOMElement
+     */
+    public function toNode(DOMDocument $document = null)
+    {
+        if (null === $document) {
+            $document = new DOMDocument();
+        }
+
+        $node = $document->createElement('EEIFilingOption');
+
+        $code = $this->getCode();
+        if (isset($code)) {
+            $node->appendChild($document->createElement('Code', $code));
+        }
+
+        $emailAddress = $this->getEmailAddress();
+        if (isset($emailAddress)) {
+            $node->appendChild($document->createElement('EMailAdress', $emailAddress));
+        }
+
+        $description = $this->getDescription();
+        if (isset($description)) {
+            $node->appendChild($document->createElement('Description', $description));
+        }
+
+        $upsFiled = $this->getUPSFiled();
+        if (isset($upsFiled)) {
+            $node->appendChild($upsFiled->toNode($document));
+        }
+
+        $shipperFiled = $this->getShipperFiled();
+        if (isset($shipperFiled)) {
+            $node->appendChild($shipperFiled->toNode($document));
+        }
+
+        return $node;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return $this
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmailAddress()
+    {
+        return $this->emailAddress;
+    }
+
+    /**
+     * @param string $emailAddress
+     *
+     * @return $this
+     */
+    public function setEmailAddress($emailAddress)
+    {
+        $this->emailAddress = $emailAddress;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     *
+     * @return $this
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * @return UPSFiled
+     */
+    public function getUPSFiled()
+    {
+        return $this->upsFiled;
+    }
+
+    /**
+     * @param UPSFiled $upsFiled
+     *
+     * @return $this
+     */
+    public function setUPSFiled(UPSFiled $upsFiled)
+    {
+        $this->upsFiled = $upsFiled;
+
+        return $this;
+    }
+
+    /**
+     * @return ShipperFiled
+     */
+    public function getShipperFiled()
+    {
+        return $this->shipperFiled;
+    }
+
+    /**
+     * @param ShipperFiled $shipperFiled
+     *
+     * @return $this
+     */
+    public function setShipperFiled(ShipperFiled $shipperFiled)
+    {
+        $this->shipperFiled = $shipperFiled;
+
+        return $this;
+    }
+}

--- a/src/Entity/InternationalForms.php
+++ b/src/Entity/InternationalForms.php
@@ -135,6 +135,11 @@ class InternationalForms implements NodeInterface
     private $freightCharges;
 
     /**
+     * @var bool
+     */
+    private $additionalDocumentIndicator;
+
+    /**
      * @return array
      */
     public static function getTypes()
@@ -303,6 +308,9 @@ class InternationalForms implements NodeInterface
         if ($this->getFreightCharges() !== null) {
             $node->appendChild($this->getFreightCharges()->toNode($document));
         }
+        if ($this->getAdditionalDocumentIndicator() !== null) {
+            $node->appendChild($document->createElement('AdditionalDocumentIndicator'));
+        }
         foreach ($this->products as $product) {
             $node->appendChild($product->toNode($document));
         }
@@ -456,5 +464,23 @@ class InternationalForms implements NodeInterface
     public function getCurrencyCode()
     {
         return $this->currencyCode;
+    }
+
+    /**
+     * @param $additionalDocumentIndicator
+     *
+     * @return $this
+     */
+    public function setAdditionalDocumentIndicator($additionalDocumentIndicator)
+    {
+        $this->additionalDocumentIndicator = $additionalDocumentIndicator;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAdditionalDocumentIndicator()
+    {
+        return $this->additionalDocumentIndicator;
     }
 }

--- a/src/Entity/InternationalForms.php
+++ b/src/Entity/InternationalForms.php
@@ -140,6 +140,11 @@ class InternationalForms implements NodeInterface
     private $additionalDocumentIndicator;
 
     /**
+     * @var EEIFilingOption
+     */
+    private $eeiFilingOption;
+
+    /**
      * @return array
      */
     public static function getTypes()
@@ -181,6 +186,9 @@ class InternationalForms implements NodeInterface
             }
             if (isset($attributes->CurrencyCode)) {
                 $this->setCurrencyCode($attributes->CurrencyCode);
+            }
+            if (isset($attributes->EEIFilingOption)) {
+                $this->setEEIFilingOption(new EEIFilingOption($attributes->EEIFilingOption));
             }
         }
     }
@@ -310,6 +318,9 @@ class InternationalForms implements NodeInterface
         }
         if ($this->getAdditionalDocumentIndicator() !== null) {
             $node->appendChild($document->createElement('AdditionalDocumentIndicator'));
+        }
+        if ($this->getEEIFilingOption() !== null) {
+            $node->appendChild($this->getEEIFilingOption()->toNode($document));
         }
         foreach ($this->products as $product) {
             $node->appendChild($product->toNode($document));
@@ -482,5 +493,25 @@ class InternationalForms implements NodeInterface
     public function getAdditionalDocumentIndicator()
     {
         return $this->additionalDocumentIndicator;
+    }
+
+    /**
+     * @param EEIFilingOption $eeiFilingOption
+     *
+     * @return $this
+     */
+    public function setEEIFilingOption(EEIFilingOption $eeiFilingOption)
+    {
+        $this->eeiFilingOption = $eeiFilingOption;
+
+        return $this;
+    }
+
+    /**
+     * @return EEIFilingOption
+     */
+    public function getEEIFilingOption()
+    {
+        return $this->eeiFilingOption;
     }
 }

--- a/src/Entity/POA.php
+++ b/src/Entity/POA.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Ups\Entity;
+
+use DOMDocument;
+use DOMElement;
+use Ups\NodeInterface;
+
+class POA implements NodeInterface
+{
+    const POA_ONE_TIME = '1';  // One Time POA
+    const POA_BLANKET  = '2';  // Blanket POA
+
+    /**
+     * @var string
+     */
+    private $code;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @param null|object $attributes
+     */
+    public function __construct($attributes = null)
+    {
+        if (null !== $attributes) {
+            if (isset($attributes->Code)) {
+                $this->setCode($attributes->Code);
+            }
+            if (isset($attributes->Description)) {
+                $this->setDescription($attributes->Description);
+            }
+        }
+    }
+
+    /**
+     * @param null|DOMDocument $document
+     *
+     * @return DOMElement
+     */
+    public function toNode(DOMDocument $document = null)
+    {
+        if (null === $document) {
+            $document = new DOMDocument();
+        }
+
+        $node = $document->createElement('POA');
+
+        $code = $this->getCode();
+        if (isset($code)) {
+            $node->appendChild($document->createElement('Code', $code));
+        }
+
+        $description = $this->getDescription();
+        if (isset($description)) {
+            $node->appendChild($document->createElement('Description', $description));
+        }
+
+        return $node;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return $this
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     *
+     * @return $this
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+}

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -33,6 +33,48 @@ class Service implements NodeInterface
     const S_UPSTODAY_EXPRESSSAVER = '86';
     const S_UPSWW_EXPRESSFREIGHT = '96';
 
+    // Time in Transit Response Service Codes: United States Domestic Shipments
+    const TT_S_US_AIR_1DAYAM    = '1DM';  // UPS Next Day Air Early
+    const TT_S_US_AIR_1DAY      = '1DA';  // UPS Next Day Air
+    const TT_S_US_AIR_SAVER     = '1DP';  // UPS Next Day Air Saver
+    const TT_S_US_AIR_2DAYAM    = '2DM';  // UPS Second Day Air A.M.
+    const TT_S_US_AIR_2DAY      = '2DA';  // UPS Second Day Air
+    const TT_S_US_3DAYSELECT    = '3DS';  // UPS Three-Day Select
+    const TT_S_US_GROUND        = 'GND';  // UPS Ground
+    const TT_S_US_AIR_1DAYSATAM = '1DMS'; // UPS Next Day Air Early (Saturday Delivery)
+    const TT_S_US_AIR_1DAYSAT   = '1DAS'; // UPS Next Day Air (Saturday Delivery)
+    const TT_S_US_AIR_2DAYSAT   = '2DAS'; // UPS Second Day Air (Saturday Delivery)
+
+    // Time in Transit Response Service Codes: Other Shipments Originating in US
+    const TT_S_US_INTL_EXPRESSPLUS = '21';  // UPS Worldwide Express Plus
+    const TT_S_US_INTL_EXPRESS     = '01';  // UPS Worldwide Express
+    const TT_S_US_INTL_SAVER       = '28';  // UPS Worldwide Express Saver
+    const TT_S_US_INTL_STANDARD    = '03';  // UPS Standard
+    const TT_S_US_INTL_EXPEDITED   = '05';  // UPS Worldwide Expedited
+
+    // Time in Transit Response Service Codes: Shipments Originating in the EU
+    // Destination is WITHIN the Origin Country
+    const TT_S_EU_EXPRESSPLUS  = '23';  // UPS Express Plus
+    const TT_S_EU_EXPRESS      = '24';  // UPS Express
+    const TT_S_EU_SAVER        = '26';  // UPS Express Saver
+    const TT_S_EU_STANDARD     = '25';  // UPS Standard
+
+    // Time in Transit Response Service Codes: Shipments Originating in the EU
+    // Destination is Another EU Country
+    const TT_S_EU_TO_EU_EXPRESSPLUS  = '22';  // UPS Express Plus
+    const TT_S_EU_TO_EU_EXPRESS      = '10';  // UPS Express
+    const TT_S_EU_TO_EU_SAVER        = '18';  // UPS Express Saver
+    const TT_S_EU_TO_EU_STANDARD     = '08';  // UPS Standard
+
+    // Time in Transit Response Service Codes: Shipments Originating in the EU
+    // Destination is Outside the EU
+    const TT_S_EU_TO_OTHER_EXPRESS_NA1  = '11';  // UPS Express NA 1
+    const TT_S_EU_TO_OTHER_EXPRESSPLUS  = '21';  // UPS Worldwide Express Plus
+    const TT_S_EU_TO_OTHER_EXPRESS      = '01';  // UPS Express
+    const TT_S_EU_TO_OTHER_SAVER        = '28';  // UPS Express Saver
+    const TT_S_EU_TO_OTHER_EXPEDITED    = '05';  // UPS Expedited
+    const TT_S_EU_TO_OTHER_STANDARD     = '68';  // UPS Standard
+
     private static $serviceNames = [
         '01' => 'UPS Next Day Air',
         '02' => 'UPS Second Day Air',

--- a/src/Entity/ShipperFiled.php
+++ b/src/Entity/ShipperFiled.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Ups\Entity;
+
+use DOMDocument;
+use DOMElement;
+use Ups\NodeInterface;
+
+class ShipperFiled implements NodeInterface
+{
+    const SF_ITN                   = 'A';  // Requires the ITN
+    const SF_EXEMPTION_LEGEND      = 'B';  // Requires the Exemption Legend
+    const SF_POST_DEPARTURE_FILING = 'C';  // Requires Post Departure Filing Citation
+
+    /**
+     * @var string
+     */
+    private $code;
+
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @var string
+     * Required if code=SF_ITN
+     */
+    private $preDepartureITNNumber;
+
+    /**
+     * @var string
+     * Required if code=SF_EXEMPTION_LEGEND
+     */
+    private $exemptionLegend;
+
+    /**
+     * @param null|object $attributes
+     */
+    public function __construct($attributes = null)
+    {
+        if (null !== $attributes) {
+            if (isset($attributes->Code)) {
+                $this->setCode($attributes->Code);
+            }
+            if (isset($attributes->Description)) {
+                $this->setDescription($attributes->Description);
+            }
+            if (isset($attributes->PreDepartureITNNumber)) {
+                $this->setPreDepartureITNNumber($attributes->PreDepartureITNNumber);
+            }
+            if (isset($attributes->ExemptionLegend)) {
+                $this->setExemptionLegend($attributes->ExemptionLegend);
+            }
+        }
+    }
+
+    /**
+     * @param null|DOMDocument $document
+     *
+     * @return DOMElement
+     */
+    public function toNode(DOMDocument $document = null)
+    {
+        if (null === $document) {
+            $document = new DOMDocument();
+        }
+
+        $node = $document->createElement('ShipperFiled');
+
+        $code = $this->getCode();
+        if (isset($code)) {
+            $node->appendChild($document->createElement('Code', $code));
+        }
+
+        $description = $this->getDescription();
+        if (isset($description)) {
+            $node->appendChild($document->createElement('Description', $description));
+        }
+
+        $preDepartureITNNumber = $this->getPreDepartureITNNumber();
+        if (isset($code)) {
+            $node->appendChild($document->createElement('PreDepartureITNNumber', $preDepartureITNNumber));
+        }
+
+        $exemptionLegend = $this->getExemptionLegend();
+        if (isset($exemptionLegend)) {
+            $node->appendChild($document->createElement('ExemptionLegend', $exemptionLegend));
+        }
+
+        return $node;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return $this
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPreDepartureITNNumber()
+    {
+        return $this->preDepartureITNNumber;
+    }
+
+    /**
+     * @param string $preDepartureITNNumber
+     *
+     * @return $this
+     */
+    public function setPreDepartureITNNumber($preDepartureITNNumber)
+    {
+        $this->preDepartureITNNumber = $preDepartureITNNumber;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExemptionLegend()
+    {
+        return $this->exemptionLegend;
+    }
+
+    /**
+     * @return string $exemptionLegend
+     */
+    public function setExemptionLegend($exemptionLegend)
+    {
+        $this->exemptionLegend = $exemptionLegend;
+
+        return $this;
+    }
+}

--- a/src/Entity/StatusType.php
+++ b/src/Entity/StatusType.php
@@ -4,8 +4,22 @@ namespace Ups\Entity;
 
 class StatusType
 {
+    const ST_IN_TRANSIT       = 'I';  // In Transit
+    const ST_DELIVERED        = 'D';  // Delivered
+    const ST_EXCEPTION        = 'X';  // Exception
+    const ST_PICKUP           = 'P';  // Pickup
+    const ST_MANIFEST_PICKUP  = 'M';  // Manifest Pickup
+
     public $Code;
     public $Description;
+
+    private $statusTypeCodes = array(
+        self::ST_IN_TRANSIT      => "In Transit",
+        self::ST_DELIVERED       => "Delivered",
+        self::ST_EXCEPTION       => "Exception",
+        self::ST_PICKUP          => "Pickup",
+        self::ST_MANIFEST_PICKUP => "Manifest Pickup"
+    );
 
     public function __construct($response = null)
     {
@@ -17,5 +31,13 @@ class StatusType
         if (isset($response->Description)) {
             $this->Description = $response->Description;
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getCodeName()
+    {
+        return $this->statusTypeCodes[$this->Code];
     }
 }

--- a/src/Entity/UPSFiled.php
+++ b/src/Entity/UPSFiled.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Ups\Entity;
+
+use DOMDocument;
+use DOMElement;
+use Ups\NodeInterface;
+
+class UPSFiled implements NodeInterface
+{
+    /**
+     * @var POA
+     */
+    private $poa;
+
+    /**
+     * @param null|object $attributes
+     */
+    public function __construct($attributes = null)
+    {
+        if (null !== $attributes) {
+            if (isset($attributes->POA)) {
+                $this->setPOA(new POA($attributes->POA));
+            }
+        }
+    }
+
+    /**
+     * @param null|DOMDocument $document
+     *
+     * @return DOMElement
+     */
+    public function toNode(DOMDocument $document = null)
+    {
+        if (null === $document) {
+            $document = new DOMDocument();
+        }
+
+        $node = $document->createElement('UPSFiled');
+
+        $poa = $this->getPOA();
+        if (isset($poa)) {
+            $node->appendChild($poa->toNode($document));
+        }
+
+        return $node;
+    }
+
+    /**
+     * @return POA
+     */
+    public function getPOA()
+    {
+        return $this->poa;
+    }
+
+    /**
+     * @return string
+     */
+    public function setPOA(POA $poa)
+    {
+        $this->poa = $poa;
+
+        return $this;
+    }
+}

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -92,7 +92,7 @@ class Unit implements NodeInterface
      */
     public function setValue($value)
     {
-        $this->value = number_format($value, 6);
+        $this->value = number_format($value, 6, '.', '');
 
         if (strlen((string)$this->value) > 19) {
             throw new \Exception('Value too long');

--- a/tests/Ups/Tests/Entity/InternationalFormsTest.php
+++ b/tests/Ups/Tests/Entity/InternationalFormsTest.php
@@ -1,0 +1,130 @@
+<?php namespace Ups\Tests\Entity;
+
+use Exception;
+use DOMDocument;
+use DOMElement;
+use PHPUnit_Framework_TestCase;
+use Ups\Entity\InternationalForms;
+use Ups\Entity\EEIFilingOption;
+use Ups\Entity\POA;
+use Ups\Entity\ShipperFiled;
+use Ups\Entity\UPSFiled;
+
+class InternationalFormsTest extends PHPUnit_Framework_TestCase
+{
+    private $data;
+
+    public function setUp()
+    {
+        $this->data = (object) (array(
+            'EEIFilingOption' => (object) (array(
+                'Code' => EEIFilingOption::FO_UPS,
+                'EmailAddress' => 'test@test.com',
+                'Description' => 'Hello World',
+                'UPSFiled' => (object) (array(
+                    'POA' => (object) (array(
+                        'Code' => POA::POA_ONE_TIME,
+                        'Description' => 'Goodbye World'
+                    ))
+                )),
+                'ShipperFiled' => (object) (array(
+                    'Code' => ShipperFiled::SF_ITN,
+                    'Description' => 'Sup Dog',
+                    'PreDepartureITNNumber' => '12345',
+                    'ExemptionLegend' => '67890'
+                ))
+            )
+        )));
+    }
+
+    public function testConstruct()
+    {
+        $eei = $this->data->EEIFilingOption;
+        $forms = new InternationalForms($this->data);
+
+        $this->assertEquals($forms->getEEIFilingOption(), new EEIFilingOption($eei));
+        $this->assertEquals($forms->getEEIFilingOption()->getCode(), $eei->Code);
+        $this->assertEquals($forms->getEEIFilingOption()->getEmailAddress(), $eei->EmailAddress);
+        $this->assertEquals($forms->getEEIFilingOption()->getDescription(), $eei->Description);
+        $this->assertEquals($forms->getEEIFilingOption()->getUPSFiled(), new UPSFiled($eei->UPSFiled));
+        $this->assertEquals($forms->getEEIFilingOption()->getUPSFiled()->getPOA(), new POA($eei->UPSFiled->POA));
+        $this->assertEquals($forms->getEEIFilingOption()->getUPSFiled()->getPOA()->getCode(), $eei->UPSFiled->POA->Code);
+        $this->assertEquals($forms->getEEIFilingOption()->getUPSFiled()->getPOA()->getDescription(), $eei->UPSFiled->POA->Description);
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled(), new ShipperFiled($eei->ShipperFiled));
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled()->getCode(), $eei->ShipperFiled->Code);
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled()->getDescription(), $eei->ShipperFiled->Description);
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled()->getPreDepartureITNNumber(), $eei->ShipperFiled->PreDepartureITNNumber);
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled()->getExemptionLegend(), $eei->ShipperFiled->ExemptionLegend);
+    }
+
+    public function testGettersAndSetters()
+    {
+        $eei = $this->data->EEIFilingOption;
+        $forms = new InternationalForms();
+
+        $this->assertEmpty($forms->getEEIFilingOption());
+
+        $forms->setEEIFilingOption(new EEIFilingOption());
+
+        $this->assertEmpty($forms->getEEIFilingOption()->getUPSFiled());
+        $this->assertEmpty($forms->getEEIFilingOption()->getShipperFiled());
+
+        $forms->getEEIFilingOption()->setUPSFiled(new UPSFiled());
+        $forms->getEEIFilingOption()->setShipperFiled(new ShipperFiled());
+
+        $this->assertEmpty($forms->getEEIFilingOption()->getUPSFiled()->getPOA());
+
+        $forms->getEEIFilingOption()->getUPSFiled()->setPOA(new POA());
+
+        $this->assertEmpty($forms->getEEIFilingOption()->getCode());
+        $this->assertEmpty($forms->getEEIFilingOption()->getEmailAddress());
+        $this->assertEmpty($forms->getEEIFilingOption()->getDescription());
+        $this->assertEmpty($forms->getEEIFilingOption()->getUPSFiled()->getPOA()->getCode());
+        $this->assertEmpty($forms->getEEIFilingOption()->getUPSFiled()->getPOA()->getDescription());
+        $this->assertEmpty($forms->getEEIFilingOption()->getShipperFiled()->getCode());
+        $this->assertEmpty($forms->getEEIFilingOption()->getShipperFiled()->getDescription());
+        $this->assertEmpty($forms->getEEIFilingOption()->getShipperFiled()->getPreDepartureITNNumber());
+        $this->assertEmpty($forms->getEEIFilingOption()->getShipperFiled()->getExemptionLegend());
+
+        $forms->getEEIFilingOption()->setCode($eei->Code);
+        $forms->getEEIFilingOption()->setDescription($eei->Description);
+        $forms->getEEIFilingOption()->setEmailAddress($eei->EmailAddress);
+        $forms->getEEIFilingOption()->getUPSFiled()->getPOA()->setCode($eei->UPSFiled->POA->Code);
+        $forms->getEEIFilingOption()->getUPSFiled()->getPOA()->setDescription($eei->UPSFiled->POA->Description);
+        $forms->getEEIFilingOption()->getShipperFiled()->setCode($eei->ShipperFiled->Code);
+        $forms->getEEIFilingOption()->getShipperFiled()->setDescription($eei->ShipperFiled->Description);
+        $forms->getEEIFilingOption()->getShipperFiled()->setPreDepartureITNNumber($eei->ShipperFiled->PreDepartureITNNumber);
+        $forms->getEEIFilingOption()->getShipperFiled()->setExemptionLegend($eei->ShipperFiled->ExemptionLegend);
+
+        $this->assertEquals($forms->getEEIFilingOption(), new EEIFilingOption($eei));
+        $this->assertEquals($forms->getEEIFilingOption()->getCode(), $eei->Code);
+        $this->assertEquals($forms->getEEIFilingOption()->getEmailAddress(), $eei->EmailAddress);
+        $this->assertEquals($forms->getEEIFilingOption()->getDescription(), $eei->Description);
+        $this->assertEquals($forms->getEEIFilingOption()->getUPSFiled(), new UPSFiled($eei->UPSFiled));
+        $this->assertEquals($forms->getEEIFilingOption()->getUPSFiled()->getPOA(), new POA($eei->UPSFiled->POA));
+        $this->assertEquals($forms->getEEIFilingOption()->getUPSFiled()->getPOA()->getCode(), $eei->UPSFiled->POA->Code);
+        $this->assertEquals($forms->getEEIFilingOption()->getUPSFiled()->getPOA()->getDescription(), $eei->UPSFiled->POA->Description);
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled(), new ShipperFiled($eei->ShipperFiled));
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled()->getCode(), $eei->ShipperFiled->Code);
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled()->getDescription(), $eei->ShipperFiled->Description);
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled()->getPreDepartureITNNumber(), $eei->ShipperFiled->PreDepartureITNNumber);
+        $this->assertEquals($forms->getEEIFilingOption()->getShipperFiled()->getExemptionLegend(), $eei->ShipperFiled->ExemptionLegend);
+    }
+
+    public function testValidXML()
+    {
+        $doc = new DOMDocument();
+        $doc->formatOutput = true;
+
+        $forms = new InternationalForms($this->data);
+        $node = $forms->toNode($doc);
+        $doc->appendChild($node);
+
+        $this->assertTrue($node instanceof DOMElement);
+        $this->assertTrue($doc instanceof DOMDocument);
+        $this->assertEquals($node->getElementsByTagName('EEIFilingOption')->length, 1);
+        $this->assertEquals($node->getElementsByTagName('ShipperFiled')->length, 1);
+        $this->assertEquals($node->getElementsByTagName('UPSFiled')->length, 1);
+        $this->assertEquals($node->getElementsByTagName('POA')->length, 1);
+    }
+}


### PR DESCRIPTION
This PR adds a handful of Time in Transit Service codes as constants to \Ups\Entity\Service.

The \Ups\Entity\Service class is used for several API calls. In particular, the Shipping, Rating, and Time in Transit requests each make use of Service.php.

Unfortunately, the UPS Service Code for Time in Transit requests is different than the codes used when requesting a rate/attempting to process a shipment.

![screen shot 2016-06-29 at 12 26 33 pm](https://cloud.githubusercontent.com/assets/4694799/16460320/c59b9814-3df4-11e6-9f9c-85f91fb39d5f.png)
