### PR TITLE
Use mb_convert_encoding when encoding detected, else try utf8_encode

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -132,9 +132,7 @@ class Request implements RequestInterface, LoggerAwareInterface
             ]);
 
             if ($response->getStatusCode() === 200) {
-                if (function_exists('mb_convert_encoding')) {
-                    $body = mb_convert_encoding($body, 'UTF-8', mb_detect_encoding($body));
-                }
+                $body = $this->convertEncoding($body);
 
                 $xml = new SimpleXMLElement($body);
                 if (isset($xml->Response) && isset($xml->Response->ResponseStatusCode)) {
@@ -218,4 +216,23 @@ class Request implements RequestInterface, LoggerAwareInterface
     {
         return $this->endpointUrl;
     }
+
+    /**
+     * @param $body
+     * @return string
+     */
+    protected function convertEncoding($body)
+    {
+        if (!function_exists('mb_convert_encoding')) {
+            return $body;
+        }
+
+        $encoding = mb_detect_encoding($body);
+        if ($encoding) {
+            return mb_convert_encoding($body, 'UTF-8', $encoding);
+        }
+
+        return utf8_encode($body);
+    }
+
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -234,5 +234,4 @@ class Request implements RequestInterface, LoggerAwareInterface
 
         return utf8_encode($body);
     }
-
 }

--- a/tests/Ups/Tests/EntityTest.php
+++ b/tests/Ups/Tests/EntityTest.php
@@ -192,5 +192,4 @@ class EntityTest extends PHPUnit_Framework_TestCase
             return [$item];
         }, $this->nodeListNoNodeInterface);
     }
-
 }

--- a/tests/Ups/Tests/ExceptionTest.php
+++ b/tests/Ups/Tests/ExceptionTest.php
@@ -24,5 +24,4 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Test Message', $exception->getMessage());
         $this->assertEquals(1, $exception->getCode());
     }
-
 }

--- a/tests/Ups/Tests/ExceptionTest.php
+++ b/tests/Ups/Tests/ExceptionTest.php
@@ -6,7 +6,6 @@ use Ups\Exception\RequestException;
 
 class ExceptionTest extends PHPUnit_Framework_TestCase
 {
-
     public function testInvalidResponseException()
     {
         $exception = new InvalidResponseException('Test Message', 1);


### PR DESCRIPTION
Basically I was getting an error sometimes: 

```
mb_convert_encoding(): Illegal character encoding specified
```

It happened that the mb_detect_encoding call was returning FALSE in some cases, which in turn let mb_convert_encoding raise an error. 

Small adjustment made to only use mb_convert_encoding in case there is a encoding known. The SimpleXmlElement object creation was not working in the same case when it was not converted to UTF-8, therefor the utf8_encode call is introduced. I'm only performing both in the situation mb_convert_encoding is available, as we only did transform things when this function exists. I can't test it very well what would happen in the case it ain't available.

@gabrielbull I think this is safe to do (and works better in my set-up), but could you also have a look?