### PR TITLE
Add note for those not using Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ run the Composer command to install the latest stable version of PHP UPS API:
 composer require gabrielbull/ups-api
 ```
 
+If not using composer, you must also include these libraries: [Guzzle](https://github.com/guzzle/guzzle), [Guzzle Promises](https://github.com/guzzle/promises), [Guzzle PSR7] (https://github.com/guzzle/psr7), [PHP-Fig PSR Log](https://github.com/php-fig/log), and [PHP-Fig HTTP Message](https://github.com/php-fig/http-message).
+
 <a name="addressvalidation-class"></a>
 ## Address Validation Class (Street Level)
 


### PR DESCRIPTION
If you don't want to use composer, it should be clear that you need these additional libraries in order to get the API running.