### PR TITLE
Support multiple form types in International Forms entity

### DIFF
--- a/src/Entity/InternationalForms.php
+++ b/src/Entity/InternationalForms.php
@@ -212,7 +212,8 @@ class InternationalForms implements NodeInterface
      *
      * @return $this
      */
-    public function setTypes(array $types) {
+    public function setTypes(array $types)
+    {
         $this->types = $types;
 
         return $this;

--- a/src/Entity/InternationalForms.php
+++ b/src/Entity/InternationalForms.php
@@ -10,9 +10,11 @@ use Ups\NodeInterface;
 class InternationalForms implements NodeInterface
 {
     /**
-     * @var string
+     * @var array
      */
-    private $type = self::TYPE_INVOICE;
+    private $types = [
+        self::TYPE_INVOICE
+    ];
 
     /**
      * Form Types.
@@ -147,17 +149,19 @@ class InternationalForms implements NodeInterface
     /**
      * @return array
      */
-    public static function getTypes()
+    public static function getFormTypes()
     {
         return self::$typeNames;
     }
 
     /**
+     * @param string $type
+     *
      * @return string
      */
-    public function getTypeName()
+    public function getFormTypeName($type)
     {
-        return self::$typeNames[$this->getType()];
+        return self::$typeNames[$type];
     }
 
     /**
@@ -200,7 +204,16 @@ class InternationalForms implements NodeInterface
      */
     public function setType($type)
     {
-        $this->type = $type;
+        return $this->setTypes([$type]);
+    }
+
+    /**
+     * @param array $types
+     *
+     * @return $this
+     */
+    public function setTypes(array $types) {
+        $this->types = $types;
 
         return $this;
     }
@@ -208,9 +221,9 @@ class InternationalForms implements NodeInterface
     /**
      * @return string
      */
-    public function getType()
+    public function getTypes()
     {
-        return $this->type;
+        return $this->types;
     }
 
     /**
@@ -286,8 +299,8 @@ class InternationalForms implements NodeInterface
 
         $node = $document->createElement('InternationalForms');
 
-        if ($this->getType()) {
-            $node->appendChild($document->createElement('FormType', $this->getType()));
+        foreach ($this->getTypes() as $type) {
+            $node->appendChild($document->createElement('FormType', $type));
         }
         if ($this->getInvoiceNumber() !== null) {
             $node->appendChild($document->createElement('InvoiceNumber', $this->getInvoiceNumber()));


### PR DESCRIPTION
Solves #152 

Warning: backwards-compatibility breaking. `getType()` method removed, and signature of `getTypes()` changed. The current `getTypes()` is renamed to `getFormTypes()`.