### PR TITLE
Fixes BeginDate and EndDate in Tracking XML Request

### DIFF
--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -283,14 +283,20 @@ class Tracking extends Ups
             $trackRequest->appendChild($xml->createElement('ShipperNumber', $this->shipperNumber));
         }
 
-        if (null !== $this->beginDate) {
-            $beginDate = $this->beginDate->format('Ymd');
-            $trackRequest->appendChild($xml->createElement('BeginDate', $beginDate));
-        }
+        if (null !== $this->beginDate || null !== $this->endDate) {
+            $DateRange = $xml->createElement('PickupDateRange');
 
-        if (null !== $this->endDate) {
-            $endDate = $this->endDate->format('Ymd');
-            $trackRequest->appendChild($xml->createElement('EndDate', $endDate));
+            if (null !== $this->beginDate) {
+                $beginDate = $this->beginDate->format('Ymd');
+                $DateRange->appendChild($xml->createElement('BeginDate', $beginDate));
+            }
+
+            if (null !== $this->endDate) {
+                $endDate = $this->endDate->format('Ymd');
+                $DateRange->appendChild($xml->createElement('EndDate', $endDate));
+            }
+
+            $trackRequest->appendChild($DateRange);
         }
 
         return $xml->saveXML();


### PR DESCRIPTION
The `BeginDate` and `EndDate` XML properties in the Tracking API need to be encapsulated in a `PickupDateRange` element.

Currently, they're being appended to the root  `TrackRequest` element.
