### PR TITLE
Add tracking data to label recovery request

### DIFF
--- a/src/Shipping.php
+++ b/src/Shipping.php
@@ -568,6 +568,14 @@ class Shipping extends Ups
 
         $request->appendChild($xml->createElement('RequestAction', 'LabelRecovery'));
 
+        if (is_string($trackingData)) {
+            $container->appendChild($xml->createElement('TrackingNumber', $trackingData));
+        } elseif (is_array($trackingData)) {
+            $referenceNumber = $container->appendChild($xml->createElement('ReferenceNumber'));
+            $referenceNumber->appendChild($xml->createElement('Value', $trackingData['value']));
+            $container->appendChild($xml->createElement('ShipperNumber', $trackingData['shipperNumber']));
+        }
+
         if (!empty($labelSpecificationOpts)) {
             $labelSpec = $request->appendChild($xml->createElement('LabelSpecification'));
 


### PR DESCRIPTION
Currently, `createRecoverLabelRequest()` takes `$trackingData` to define which label to recover, but doesn't actually use it in the request.
This adds the passed data to the XML, making the request valid.