### PR TITLE
Change Next Day Air Saver to UPS Next Day Air Saver for consistency

### DIFF
--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -84,7 +84,7 @@ class Service implements NodeInterface
         '08' => 'UPS Worldwide Expedited',
         '11' => 'UPS Standard',
         '12' => 'UPS Three-Day Select',
-        '13' => 'Next Day Air Saver',
+        '13' => 'UPS Next Day Air Saver',
         '14' => 'UPS Next Day Air Early AM',
         '54' => 'UPS Worldwide Express Plus',
         '59' => 'UPS Second Day Air AM',


### PR DESCRIPTION
Just a simple pull request to update the name of `Next Day Air Saver`, to `UPS Next Day Air Saver` for consistency reasons.

Related: https://github.com/gabrielbull/php-ups-api/issues/208
Tests run, 163 passed, PHP 7.0.26

I've tried to run the tests on PHP 5.5, but I am hitting severe issues with PHP 5.6 dependencies

```
  Problem 1
    - Installation request for myclabs/deep-copy 1.7.0 -> satisfiable by myclabs/deep-copy[1.7.0].
    - myclabs/deep-copy 1.7.0 requires php ^5.6 || ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 2
    - Installation request for phpdocumentor/reflection-docblock 4.3.0 -> satisfiable by phpdocumentor/reflection-docblock[4.3.0].
    - phpdocumentor/reflection-docblock 4.3.0 requires php ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 3
    - Installation request for phpunit/php-code-coverage 4.0.8 -> satisfiable by phpunit/php-code-coverage[4.0.8].
    - phpunit/php-code-coverage 4.0.8 requires php ^5.6 || ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 4
    - Installation request for phpunit/php-token-stream 2.0.2 -> satisfiable by phpunit/php-token-stream[2.0.2].
    - phpunit/php-token-stream 2.0.2 requires php ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 5
    - Installation request for phpunit/phpunit 5.7.27 -> satisfiable by phpunit/phpunit[5.7.27].
    - phpunit/phpunit 5.7.27 requires php ^5.6 || ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 6
    - Installation request for phpunit/phpunit-mock-objects 3.4.4 -> satisfiable by phpunit/phpunit-mock-objects[3.4.4].
    - phpunit/phpunit-mock-objects 3.4.4 requires php ^5.6 || ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 7
    - Installation request for sebastian/code-unit-reverse-lookup 1.0.1 -> satisfiable by sebastian/code-unit-reverse-lookup[1.0.1].
    - sebastian/code-unit-reverse-lookup 1.0.1 requires php ^5.6 || ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 8
    - Installation request for sebastian/environment 2.0.0 -> satisfiable by sebastian/environment[2.0.0].
    - sebastian/environment 2.0.0 requires php ^5.6 || ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 9
    - Installation request for sebastian/object-enumerator 2.0.1 -> satisfiable by sebastian/object-enumerator[2.0.1].
    - sebastian/object-enumerator 2.0.1 requires php >=5.6 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 10
    - Installation request for sebastian/resource-operations 1.0.0 -> satisfiable by sebastian/resource-operations[1.0.0].
    - sebastian/resource-operations 1.0.0 requires php >=5.6.0 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 11
    - Installation request for sebastian/version 2.0.1 -> satisfiable by sebastian/version[2.0.1].
    - sebastian/version 2.0.1 requires php >=5.6 -> your PHP version (5.5.38) does not satisfy that requirement.
  Problem 12
    - phpdocumentor/reflection-docblock 4.3.0 requires php ^7.0 -> your PHP version (5.5.38) does not satisfy that requirement.
    - phpspec/prophecy 1.7.5 requires phpdocumentor/reflection-docblock ^2.0|^3.0.2|^4.0 -> satisfiable by phpdocumentor/reflection-docblock[4.3.0].
    - Installation request for phpspec/prophecy 1.7.5 -> satisfiable by phpspec/prophecy[1.7.5].
```

And with PHP 5.6, I get issues with PHP 7.0

```
  Problem 1
    - Installation request for phpdocumentor/reflection-docblock 4.3.0 -> satisfiable by phpdocumentor/reflection-docblock[4.3.0].
    - phpdocumentor/reflection-docblock 4.3.0 requires php ^7.0 -> your PHP version (5.6.32) does not satisfy that requirement.
  Problem 2
    - Installation request for phpunit/php-token-stream 2.0.2 -> satisfiable by phpunit/php-token-stream[2.0.2].
    - phpunit/php-token-stream 2.0.2 requires php ^7.0 -> your PHP version (5.6.32) does not satisfy that requirement.
  Problem 3
    - phpdocumentor/reflection-docblock 4.3.0 requires php ^7.0 -> your PHP version (5.6.32) does not satisfy that requirement.
    - phpspec/prophecy 1.7.5 requires phpdocumentor/reflection-docblock ^2.0|^3.0.2|^4.0 -> satisfiable by phpdocumentor/reflection-docblock[4.3.0].
```

I think your lock file may need altering, as PHPUnit appears to be requiring a version that insists on PHP 5.6/7.0? If I run `composer install --no-dev` it installs fine on PHP 5.5/5.6