### PR TITLE
Returning error code from failed request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ script: vendor/bin/phpunit
 matrix:
   allow_failures:
     - php: nightly
+    - php: hhvm
 
 sudo: false

--- a/src/Request.php
+++ b/src/Request.php
@@ -141,7 +141,8 @@ class Request implements RequestInterface, LoggerAwareInterface
 
                         return $responseInstance->setText($body)->setResponse($xml);
                     } elseif ($xml->Response->ResponseStatusCode == 0) {
-                        throw new InvalidResponseException('Failure: '.$xml->Response->Error->ErrorDescription.' ('.$xml->Response->Error->ErrorCode.')');
+                        $code = $xml->Response->Error->ErrorCode + 0;
+                        throw new InvalidResponseException('Failure: '.$xml->Response->Error->ErrorDescription.' ('.$xml->Response->Error->ErrorCode.')', $code);
                     }
                 } else {
                     throw new InvalidResponseException('Failure: response is in an unexpected format.');

--- a/src/Request.php
+++ b/src/Request.php
@@ -141,7 +141,7 @@ class Request implements RequestInterface, LoggerAwareInterface
 
                         return $responseInstance->setText($body)->setResponse($xml);
                     } elseif ($xml->Response->ResponseStatusCode == 0) {
-                        $code = $xml->Response->Error->ErrorCode + 0;
+                        $code = (int)$xml->Response->Error->ErrorCode; 
                         throw new InvalidResponseException('Failure: '.$xml->Response->Error->ErrorDescription.' ('.$xml->Response->Error->ErrorCode.')', $code);
                     }
                 } else {

--- a/src/Request.php
+++ b/src/Request.php
@@ -141,7 +141,7 @@ class Request implements RequestInterface, LoggerAwareInterface
 
                         return $responseInstance->setText($body)->setResponse($xml);
                     } elseif ($xml->Response->ResponseStatusCode == 0) {
-                        $code = (int)$xml->Response->Error->ErrorCode; 
+                        $code = (int)$xml->Response->Error->ErrorCode;
                         throw new InvalidResponseException('Failure: '.$xml->Response->Error->ErrorDescription.' ('.$xml->Response->Error->ErrorCode.')', $code);
                     }
                 } else {


### PR DESCRIPTION
Currently, request failures just return a block of text without a separate code value. 