### PR TITLE
Add error location if available

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -142,7 +142,21 @@ class Request implements RequestInterface, LoggerAwareInterface
                         return $responseInstance->setText($body)->setResponse($xml);
                     } elseif ($xml->Response->ResponseStatusCode == 0) {
                         $code = (int)$xml->Response->Error->ErrorCode;
-                        throw new InvalidResponseException('Failure: '.$xml->Response->Error->ErrorDescription.' ('.$xml->Response->Error->ErrorCode.')', $code);
+                        
+                        $message = sprintf(
+                            'Failure: %s (%d)',
+                            $xml->Response->Error->ErrorDescription,
+                            $code
+                        );
+
+                        if( isset($xml->Response->Error->ErrorLocation, $xml->Response->Error->ErrorLocation->ErrorLocationElementName) ) {
+                            $message .= sprintf(
+                                ' (Error location: %s)',
+                                $xml->Response->Error->ErrorLocation->ErrorLocationElementName
+                            );
+                        }
+
+                        throw new InvalidResponseException($message, $code);
                     }
                 } else {
                     throw new InvalidResponseException('Failure: response is in an unexpected format.');

--- a/src/Request.php
+++ b/src/Request.php
@@ -149,7 +149,7 @@ class Request implements RequestInterface, LoggerAwareInterface
                             $code
                         );
 
-                        if( isset($xml->Response->Error->ErrorLocation, $xml->Response->Error->ErrorLocation->ErrorLocationElementName) ) {
+                        if(isset($xml->Response->Error->ErrorLocation, $xml->Response->Error->ErrorLocation->ErrorLocationElementName)) {
                             $message .= sprintf(
                                 ' (Error location: %s)',
                                 $xml->Response->Error->ErrorLocation->ErrorLocationElementName

--- a/src/Request.php
+++ b/src/Request.php
@@ -149,7 +149,7 @@ class Request implements RequestInterface, LoggerAwareInterface
                             $code
                         );
 
-                        if(isset($xml->Response->Error->ErrorLocation, $xml->Response->Error->ErrorLocation->ErrorLocationElementName)) {
+                        if (isset($xml->Response->Error->ErrorLocation, $xml->Response->Error->ErrorLocation->ErrorLocationElementName)) {
                             $message .= sprintf(
                                 ' (Error location: %s)',
                                 $xml->Response->Error->ErrorLocation->ErrorLocationElementName


### PR DESCRIPTION
Sometimes i got 'The XML document is well formed but the document is not valid.' (10002) and I didn't know where was the error.

Now, it will be printed if available.

I don't know that it is depend on error code 10002, so I added it with isset check.