### PR TITLE
Add guzzle 7 on required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   ],
   "require": {
     "php": "^5.5 || ^7.0",
-    "guzzlehttp/guzzle": "^6.0",
+    "guzzlehttp/guzzle": "^6.0 || ^7.0",
     "psr/log": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Added Guzzle 7, the last major version of Guzzle at this moment. I didn't increased the version of the package, I am not sure since is not a bug fix nor a new feature.