### PR TITLE
added TaxInformationIndicator support

### DIFF
--- a/src/Entity/Shipment.php
+++ b/src/Entity/Shipment.php
@@ -596,7 +596,7 @@ class Shipment
         $this->shipmentTotalWeight = $shipmentTotalWeight;
     }
 
-    public function getTaxInformationIndicator()
+    public function getTaxInformationIndicator(): bool
     {
         return $this->taxInformationIndicator;
     }
@@ -604,8 +604,10 @@ class Shipment
     /**
      * If called, returned prices will include Tax Information
      */
-    public function useTaxInformationIndicator()
+    public function setTaxInformationIndicator(bool $taxInformationIndicator): self
     {
-        $this->taxInformationIndicator = true;
+        $this->taxInformationIndicator = $taxInformationIndicator;
+        
+        return $this;
     }
 }

--- a/src/Entity/Shipment.php
+++ b/src/Entity/Shipment.php
@@ -78,7 +78,7 @@ class Shipment
      * @var ReferenceNumber
      */
     private $referenceNumber;
-    
+
     /**
      * @var ReferenceNumber
      */
@@ -103,7 +103,7 @@ class Shipment
      * @var InvoiceLineTotal
      */
     private $invoiceLineTotal;
-    
+
     /**
      * @var ShipmentTotalWeight
      */
@@ -118,6 +118,10 @@ class Shipment
      * @var DeliveryTimeInformation
      */
     private $deliveryTimeInformation;
+    /**
+     * @var bool
+     */
+    private $taxInformationIndicator;
 
     public function __construct()
     {
@@ -126,6 +130,7 @@ class Shipment
         $this->setShipmentServiceOptions(new ShipmentServiceOptions());
         $this->setService(new Service());
         $this->rateInformation = null;
+        $this->taxInformationIndicator = false;
     }
 
     /**
@@ -205,7 +210,7 @@ class Shipment
 
         return $this;
     }
-    
+
     /**
      * @param ReferenceNumber $referenceNumber
      *
@@ -225,7 +230,7 @@ class Shipment
     {
         return $this->referenceNumber;
     }
-    
+
     /**
      * @return ReferenceNumber
      */
@@ -574,7 +579,7 @@ class Shipment
     {
         $this->deliveryTimeInformation = $deliveryTimeInformation;
     }
-    
+
     /**
      * @return ShipmentTotalWeight
      */
@@ -589,5 +594,18 @@ class Shipment
     public function setShipmentTotalWeight(ShipmentTotalWeight $shipmentTotalWeight)
     {
         $this->shipmentTotalWeight = $shipmentTotalWeight;
+    }
+
+    public function getTaxInformationIndicator()
+    {
+        return $this->taxInformationIndicator;
+    }
+
+    /**
+     * If called, returned prices will include Tax Information
+     */
+    public function useTaxInformationIndicator()
+    {
+        $this->taxInformationIndicator = true;
     }
 }

--- a/src/Rate.php
+++ b/src/Rate.php
@@ -201,7 +201,7 @@ class Rate extends Ups
             $shipmentNode->appendChild($InvoiceLineTotal->toNode($xml));
         }
 
-        if($shipment->getTaxInformationIndicator()) {
+        if ($shipment->getTaxInformationIndicator()) {
             $shipmentNode->appendChild($xml->createElement('TaxInformationIndicator'));
         }
 

--- a/src/Rate.php
+++ b/src/Rate.php
@@ -190,15 +190,19 @@ class Rate extends Ups
         if (isset($deliveryTimeInformation)) {
             $shipmentNode->appendChild($deliveryTimeInformation->toNode($xml));
         }
-          
+
         $ShipmentTotalWeight = $shipment->getShipmentTotalWeight();
         if (isset($ShipmentTotalWeight)) {
             $shipmentNode->appendChild($ShipmentTotalWeight->toNode($xml));
         }
-        
+
         $InvoiceLineTotal = $shipment->getInvoiceLineTotal();
         if (isset($InvoiceLineTotal)) {
             $shipmentNode->appendChild($InvoiceLineTotal->toNode($xml));
+        }
+
+        if($shipment->getTaxInformationIndicator()) {
+            $shipmentNode->appendChild($xml->createElement('TaxInformationIndicator'));
         }
 
         return $xml->saveXML();


### PR DESCRIPTION
Possible solution to [issue:306](https://github.com/gabrielbull/php-ups-api/issues/306)

Because of the nature of the indicatior (Presence/Absence Indicator, Any value inside is ignored) I'm not sure how to correctly name the setter/getter, and if it should have its own class with `toNode` implementation