### PR TITLE
Add LabelLinksIndicator to LabelDelivery for ShipmentServiceOption

### DIFF
--- a/src/Entity/LabelDelivery.php
+++ b/src/Entity/LabelDelivery.php
@@ -14,6 +14,11 @@ class LabelDelivery implements NodeInterface
     public $LabelLinkIndicator;
 
     /**
+     * @var boolean
+     */
+    public $LabelLinksIndicator;
+
+    /**
      * @var string
      */
     public $EMailAddress;
@@ -55,9 +60,15 @@ class LabelDelivery implements NodeInterface
     {
         $this->LabelLinkIndicator = null;
 
+        $this->LabelLinksIndicator = null;
+
         if (null !== $response) {
             if (isset($response->LabelLinkIndicator)) {
                 $this->LabelLinkIndicator = true;
+            }
+
+            if (isset($response->LabelLinksIndicator)) {
+                $this->LabelLinksIndicator = true;
             }
 
             if (isset($response->EMailAddress)) {
@@ -106,6 +117,10 @@ class LabelDelivery implements NodeInterface
             $node->appendChild($document->createElement('LabelLinkIndicator', $this->LabelLinkIndicator));
         }
 
+        if (isset($this->LabelLinksIndicator)) {
+            $node->appendChild($document->createElement('LabelLinksIndicator', $this->LabelLinksIndicator));
+        }
+
         if (isset($this->EMailAddress)) {
             $node->appendChild($document->createElement('EMailAddress', $this->EMailAddress));
         }
@@ -151,6 +166,24 @@ class LabelDelivery implements NodeInterface
     public function setLabelLinkIndicator($labelLinkIndicator)
     {
         $this->LabelLinkIndicator = $labelLinkIndicator;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabelLinksIndicator()
+    {
+        return $this->LabelLinksIndicator;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setLabelLinksIndicator($labelLinksIndicator)
+    {
+        $this->LabelLinksIndicator = $labelLinksIndicator;
 
         return $this;
     }

--- a/src/Entity/ShipmentServiceOptions.php
+++ b/src/Entity/ShipmentServiceOptions.php
@@ -188,7 +188,7 @@ class ShipmentServiceOptions implements NodeInterface
             $emailMessageNode = $labelDeliveryNode->appendChild($document->createElement('EMailMessage'));
             $labelDelivery = $this->getLabelDelivery();
             foreach ($labelDelivery as $key => $value) {
-                if ($key == 'LabelLinkIndicator') {
+                if ($key == 'LabelLinksIndicator') {
                     $labelDeliveryNode->appendChild($document->createElement($key, $value));
                 } elseif ($key == 'SubjectCode') {
                     $SubjectNode = $emailMessageNode->appendChild($document->createElement('Subject'));


### PR DESCRIPTION
Hi again!

At work, we realized what could be a small error. For ShipmentServiceOptions, the node expects a LabelLinksIndicator instead of the LabelLinkIndicator (note the 's'), in contrast with the LabelRecoveryRequest which indeed expects the LabelLinkIndicator, without the 's'.

The result was that the URL was not returned in the accept response.

To fix that, we added an option to set LabelLinksIndicator modifying as well the relevant ```if``` statement for ShipmentServiceOptions.

Again, let me know if I need to do something else in order to have it merged.

Cheers!
X.

