### PR TITLE
Added Missing Carbon Neutral Additional Option to ShipmentServiceOptions Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ Tracking API, Shipping API, Rating API and Time in Transit API. Feel free to con
 12. [Shipping Class](#shipping-class)
     * [Example](#shipping-class-example)
     * [Parameters](#shipping-class-parameters)
-13. [Logging](#logging)
-14. [License](#license-section)
+12. [Shipment Service Options](#shipment-service-options)
+    * [Example](#shipment-service-options-example)
+14. [Logging](#logging)
+15. [License](#license-section)
 
 <a name="requirements"></a>
 ## Requirements
@@ -839,6 +841,35 @@ For the Shipping `confirm` call, the parameters are:
 For the Shipping `accept` call, the parameters are: 
 
  * $shipmentDigest The UPS Shipment Digest received from a ShipConfirm request. Required
+
+
+<a name="shipment-service-options"></a>
+## Shipment Service Options
+
+The Shipment Service Options class allows you to register shipments additional options. This also includes.
+
+
+* Add or Modify email notifications: Manage updates for this shipment.
+* Saturday Commericial: Get weekend delivery of your shipment.
+* Deliver only to receiver's address: Do not reroute for customer pickup at a UPS location.
+* UPS Carbon Neutral Shipments Thanks for offsetting the environmental impact of your shipment! : at a nominal fee for domestic and international shipments.
+
+
+In the example ShipmentServiceOptions class is used to show how a Shipment Additional Option can be added to Shipment. 
+<a name="shipment-service-options-example"></a>
+### Shipment Service Options Example
+
+```php
+// Start shipment
+$shipment = new Ups\Entity\Shipment;
+
+// Create Shipment Service Options Class
+    $shipmentOptions = new Ups\Entity\ShipmentServiceOptions;
+    // Setting the Carbon Neutral Additional Option, you can set your desired one.
+    $shipmentOptions->setUPScarbonneutralIndicator();
+// Set Shipment Service Options Class
+    $shipment->setShipmentServiceOptions($shipmentOptions);
+```
 
 <a name="logging"></a>
 ## Logging

--- a/src/Entity/ShipmentServiceOptions.php
+++ b/src/Entity/ShipmentServiceOptions.php
@@ -51,6 +51,11 @@ class ShipmentServiceOptions implements NodeInterface
     /**
      * @var
      */
+    public $UPScarbonneutralIndicator;
+
+    /**
+     * @var
+     */
     private $internationalForms;
 
     /**
@@ -467,5 +472,21 @@ class ShipmentServiceOptions implements NodeInterface
     {
         $this->DeliverToAddresseeOnlyIndicator = $DeliverToAddresseeOnlyIndicator;
         return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUPScarbonneutralIndicator()
+    {
+        return $this->UPScarbonneutralIndicator;
+    }
+
+    /**
+     * @param mixed $UPScarbonneutralIndicator
+     */
+    public function setUPScarbonneutralIndicator(): void
+    {
+        $this->UPScarbonneutralIndicator = true;
     }
 }


### PR DESCRIPTION
Kindly merge this Branch, As I need to use this in a Project and I will be waiting for your guys to update the package so I don't have to face any difficulty, Thanks.  
Its tested , and its working fine with the UPS, and also making the Labels with the Test **UPS CARBON NEUTRAL SHIPMENT**
Check the Attached ScreenShots. 1st for the Label and 2nd for the UPS Receipt.

**UPS Label Generated**

![image](https://user-images.githubusercontent.com/79155472/153891019-f6c80137-9257-4b8b-91d9-30f7a84a9afd.png)

**UPS Rceipt**

![image](https://user-images.githubusercontent.com/79155472/153891370-d0a512f3-5b53-4bb9-92ec-5f8c26d6968c.png)
