### PR TITLE
Allow BillThirdPartyConsignee to be set in ItemizedPaymentInformation

### DIFF
--- a/src/Entity/PaymentInformation.php
+++ b/src/Entity/PaymentInformation.php
@@ -22,6 +22,11 @@ class PaymentInformation
     private $billThirdParty;
 
     /**
+     * @var BillThirdParty
+     */
+    private $billThirdPartyConsignee;
+
+    /**
      * @var FreightCollect
      */
     private $freightCollect;
@@ -85,6 +90,25 @@ class PaymentInformation
     public function setBillThirdParty(BillThirdParty $billThirdParty = null)
     {
         $this->billThirdParty = $billThirdParty;
+
+        return $this;
+    }
+
+    /**
+     * @return BillThirdParty
+     */
+    public function getBillThirdPartyConsignee()
+    {
+        return $this->billThirdPartyConsignee;
+    }
+
+    /**
+     * @param BillThirdParty $billThirdPartyConsignee
+     * @return PaymentInformation
+     */
+    public function setBillThirdPartyConsignee(BillThirdParty $billThirdPartyConsignee = null)
+    {
+        $this->billThirdPartyConsignee = $billThirdPartyConsignee;
 
         return $this;
     }

--- a/src/Entity/PaymentInformation.php
+++ b/src/Entity/PaymentInformation.php
@@ -95,25 +95,6 @@ class PaymentInformation
     }
 
     /**
-     * @return BillThirdParty
-     */
-    public function getBillThirdPartyConsignee()
-    {
-        return $this->billThirdPartyConsignee;
-    }
-
-    /**
-     * @param BillThirdParty $billThirdPartyConsignee
-     * @return PaymentInformation
-     */
-    public function setBillThirdPartyConsignee(BillThirdParty $billThirdPartyConsignee = null)
-    {
-        $this->billThirdPartyConsignee = $billThirdPartyConsignee;
-
-        return $this;
-    }
-
-    /**
      * @return FreightCollect
      */
     public function getFreightCollect()

--- a/src/Entity/ShipmentCharge.php
+++ b/src/Entity/ShipmentCharge.php
@@ -34,6 +34,11 @@ class ShipmentCharge
     private $billThirdParty;
 
     /**
+    * @var BillThirdParty
+    */
+   private $billThirdPartyConsignee;
+
+    /**
      * @var bool
      */
     private $consigneeBilled;
@@ -101,6 +106,25 @@ class ShipmentCharge
     public function setBillThirdParty(BillThirdParty $billThirdParty = null)
     {
         $this->billThirdParty = $billThirdParty;
+
+        return $this;
+    }
+
+	/**
+     * @return BillThirdParty
+     */
+    public function getBillThirdPartyConsignee()
+    {
+        return $this->billThirdPartyConsignee;
+    }
+
+    /**
+     * @param BillThirdParty $billThirdPartyConsignee
+     * @return ShipmentCharge
+     */
+    public function setBillThirdPartyConsignee(BillThirdParty $billThirdPartyConsignee = null)
+    {
+        $this->billThirdPartyConsignee = $billThirdPartyConsignee;
 
         return $this;
     }

--- a/src/Shipping.php
+++ b/src/Shipping.php
@@ -355,16 +355,30 @@ class Shipping extends Ups
                     $node = $node->appendChild($xml->createElement('BillThirdParty'));
                     $btpNode = $node->appendChild($xml->createElement('BillThirdPartyShipper'));
                     $btpNode->appendChild($xml->createElement('AccountNumber', $rec->getBillThirdParty()->getAccountNumber()));
-    
+
                     $tpNode = $btpNode->appendChild($xml->createElement('ThirdParty'));
                     $addressNode = $tpNode->appendChild($xml->createElement('Address'));
-    
+
                     $thirdPartAddress = $rec->getBillThirdParty()->getThirdPartyAddress();
                     if (isset($thirdPartAddress) && $rec->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()) {
                         $addressNode->appendChild($xml->createElement('PostalCode', $rec->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()));
                     }
-    
+
                     $addressNode->appendChild($xml->createElement('CountryCode', $rec->getBillThirdParty()->getThirdPartyAddress()->getCountryCode()));
+                } elseif ($rec->getBillThirdPartyConsignee()) {
+                    $node = $node->appendChild($xml->createElement('BillThirdParty'));
+                    $btpNode = $node->appendChild($xml->createElement('BillThirdPartyConsignee'));
+                    $btpNode->appendChild($xml->createElement('AccountNumber', $rec->getBillThirdPartyConsignee()->getAccountNumber()));
+
+                    $tpNode = $btpNode->appendChild($xml->createElement('ThirdParty'));
+                    $addressNode = $tpNode->appendChild($xml->createElement('Address'));
+
+                    $thirdPartAddress = $rec->getBillThirdPartyConsignee()->getThirdPartyAddress();
+                    if (isset($thirdPartAddress) && $rec->getBillThirdPartyConsignee()->getThirdPartyAddress()->getPostalCode()) {
+                        $addressNode->appendChild($xml->createElement('PostalCode', $rec->getBillThirdPartyConsignee()->getThirdPartyAddress()->getPostalCode()));
+                    }
+
+                    $addressNode->appendChild($xml->createElement('CountryCode', $rec->getBillThirdPartyConsignee()->getThirdPartyAddress()->getCountryCode()));
                 } elseif ($rec->getConsigneeBilled()) {
                     $node->appendChild($xml->createElement('ConsigneeBilled'));
                 }


### PR DESCRIPTION
As per the [UPS OnLine® Tools Shipping XML Tool  Developers Guide (non-official link)](https://idaho-dental-studio.com/wp-content/uploads/2012/11/Shipping-Package-XML-Developers-Guide.pdf) (page 76), the `BillThirdPartyConsignee` element can be present instead of the `BillThirdPartyShipper` inside of a `ItemizedPaymentInformation` element:

>This element or its sibling element, BillThirdPartyShipper, must be present but no more than one can be present.

The purpose of this field is to have a separate `BillThirdParty` inside your `ItemizedPaymentInformation` that is _not_ charged for shipping, but (for example) only for duties and taxes (using the `SHIPMENT_CHARGE_TYPE_DUTIES` type on the `ShipmentCharge`).

In this pull request I've repurposed the main `BillThirdParty` object to be passed as a `BillThirdPartyShipper` parameter, as they are identical in terms of fields and methods. I'm open to suggestions to make this more optimal, if needed.