### PR TITLE
Setting Wednesday constant to WED

### DIFF
--- a/src/Entity/EstimatedArrival.php
+++ b/src/Entity/EstimatedArrival.php
@@ -8,7 +8,7 @@ class EstimatedArrival
 
     const EA_MONDAY = 'MON';
     const EA_TUESDAY = 'TUE';
-    const EA_WEDNESDAY = 'WEB';
+    const EA_WEDNESDAY = 'WED';
     const EA_THUSDAY = 'THU';
     const EA_FRIDAY = 'FRI';
     const EA_SATURDAY = 'SAT';


### PR DESCRIPTION
The EA_WEDNESDAY constant appears to be set to an incorrect value of `'WEB'`. I guess I am assuming that this is a typo, but could certainly be a false assumption.

This constant doesn't appear to be used within the code, so this is the only instance of it that I can see.