### PR TITLE
reduce copy/past ref. `AccountNumber`

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ if ($return) {
 $shipment->setReferenceNumber($referenceNumber);
 
 // Set payment information
-$shipment->setPaymentInformation(new \Ups\Entity\PaymentInformation('prepaid', (object)array('AccountNumber' => 'XX')));
+$shipment->setPaymentInformation(new \Ups\Entity\PaymentInformation('prepaid', (object) ['AccountNumber' => $shipper->getShipperNumber()]));
 
 // Ask for negotiated rates (optional)
 $rateInformation = new \Ups\Entity\RateInformation;


### PR DESCRIPTION
[string(6)] "Must be the same UPS account number as the one provided in Shipper/ShipperNumber"