### PR TITLE
Add NumOfPieces in Shipment to Rate Service to allow use of 'UPS Worl…

### DIFF
--- a/src/Rate.php
+++ b/src/Rate.php
@@ -167,6 +167,10 @@ class Rate extends Ups
             $shipmentNode->appendChild($alternateDeliveryAddress->toNode($document));
         }
 
+        if ($shipment->getNumOfPiecesInShipment()) {
+            $shipmentNode->appendChild($xml->createElement('NumOfPieces', $shipment->getNumOfPiecesInShipment()));
+        }
+
         $rateInformation = $shipment->getRateInformation();
         if ($rateInformation !== null) {
             $shipmentNode->appendChild($rateInformation->toNode($document));


### PR DESCRIPTION
When trying to use service "UPS Worldwide Express Freight" (`96`), UPS API throws an error:
```
The number of pieces was not provided - Number of pieces in a shipment is required to process the shipment. (112053)"
```

This pull request adds `NumOfPieces` to `Shipment` Entity in Rate Service, which fixes above error.