### PR TITLE
add htmlspecialchars to escape & characters to solve issue 374

### DIFF
--- a/src/AddressValidation.php
+++ b/src/AddressValidation.php
@@ -166,45 +166,46 @@ class AddressValidation extends Ups
         $request->appendChild($xml->createElement('RequestAction', 'XAV'));
 
         if (null !== $this->requestOption) {
-            $request->appendChild($xml->createElement('RequestOption', $this->requestOption));
+            $request->appendChild($xml->createElement('RequestOption', ($this->requestOption) !== null ? htmlspecialchars($this->requestOption) : null));
         }
 
         if (null !== $this->maxSuggestion) {
-            $avRequest->appendChild($xml->createElement('MaximumListSize', $this->maxSuggestion));
+            $avRequest->appendChild($xml->createElement('MaximumListSize', ($this->maxSuggestion) !== null ? htmlspecialchars($this->maxSuggestion) : null));
         }
 
         if (null !== $this->address) {
             $addressNode = $avRequest->appendChild($xml->createElement('AddressKeyFormat'));
 
             if ($this->address->getAttentionName()) {
-                $addressNode->appendChild($xml->createElement('ConsigneeName', $this->address->getAttentionName()));
+                $addressNode->appendChild($xml->createElement('ConsigneeName', ($this->address->getAttentionName()) !== null ? htmlspecialchars($this->address->getAttentionName()) : null));
             }
             if ($this->address->getBuildingName()) {
-                $addressNode->appendChild($xml->createElement('BuildingName', $this->address->getBuildingName()));
+                $addressNode->appendChild($xml->createElement('BuildingName', ($this->address->getBuildingName()) !== null ? htmlspecialchars($this->address->getBuildingName()) : null));
             }
             if ($this->address->getAddressLine1()) {
-                $addressNode->appendChild($xml->createElement('AddressLine', $this->address->getAddressLine1()));
+                $addressNode->appendChild($xml->createElement('AddressLine', ($this->address->getAddressLine1()) !== null ? htmlspecialchars($this->address->getAddressLine1()) : null));
             }
             if ($this->address->getAddressLine2()) {
-                $addressNode->appendChild($xml->createElement('AddressLine', $this->address->getAddressLine2()));
+                $addressNode->appendChild($xml->createElement('AddressLine', ($this->address->getAddressLine2()) !== null ? htmlspecialchars($this->address->getAddressLine2()) : null));
             }
             if ($this->address->getAddressLine3()) {
-                $addressNode->appendChild($xml->createElement('AddressLine', $this->address->getAddressLine3()));
+                $addressNode->appendChild($xml->createElement('AddressLine', ($this->address->getAddressLine3()) !== null ? htmlspecialchars($this->address->getAddressLine3()) : null));
             }
             if ($this->address->getStateProvinceCode()) {
                 $addressNode->appendChild($xml->createElement(
                     'PoliticalDivision1',
-                    $this->address->getStateProvinceCode()
-                ));
+                    ($this->address->getStateProvinceCode()
+                ) !== null ? htmlspecialchars($this->address->getStateProvinceCode()
+                ) : null));
             }
             if ($this->address->getCity()) {
-                $addressNode->appendChild($xml->createElement('PoliticalDivision2', $this->address->getCity()));
+                $addressNode->appendChild($xml->createElement('PoliticalDivision2', ($this->address->getCity()) !== null ? htmlspecialchars($this->address->getCity()) : null));
             }
             if ($this->address->getCountryCode()) {
-                $addressNode->appendChild($xml->createElement('CountryCode', $this->address->getCountryCode()));
+                $addressNode->appendChild($xml->createElement('CountryCode', ($this->address->getCountryCode()) !== null ? htmlspecialchars($this->address->getCountryCode()) : null));
             }
             if ($this->address->getPostalCode()) {
-                $addressNode->appendChild($xml->createElement('PostcodePrimaryLow', $this->address->getPostalCode()));
+                $addressNode->appendChild($xml->createElement('PostcodePrimaryLow', ($this->address->getPostalCode()) !== null ? htmlspecialchars($this->address->getPostalCode()) : null));
             }
         }
 

--- a/src/Entity/AccessPointCOD.php
+++ b/src/Entity/AccessPointCOD.php
@@ -51,8 +51,8 @@ class AccessPointCOD implements NodeInterface
 
         $node = $document->createElement('AccessPointCOD');
 
-        $node->appendChild($document->createElement('CurrencyCode', $this->getCurrencyCode()));
-        $node->appendChild($document->createElement('MonetaryValue', $this->getMonetaryValue()));
+        $node->appendChild($document->createElement('CurrencyCode', ($this->getCurrencyCode()) !== null ? htmlspecialchars($this->getCurrencyCode()) : null));
+        $node->appendChild($document->createElement('MonetaryValue', ($this->getMonetaryValue()) !== null ? htmlspecialchars($this->getMonetaryValue()) : null));
 
         return $node;
     }

--- a/src/Entity/AccessPointSearch.php
+++ b/src/Entity/AccessPointSearch.php
@@ -43,15 +43,15 @@ class AccessPointSearch implements NodeInterface
         $node = $document->createElement('AccessPointSearch');
 
         if ($this->getAccessPointStatus()) {
-            $node->appendChild($document->createElement('AccessPointStatus', $this->getAccessPointStatus()));
+            $node->appendChild($document->createElement('AccessPointStatus', ($this->getAccessPointStatus()) !== null ? htmlspecialchars($this->getAccessPointStatus()) : null));
         }
 
         if ($this->getPublicAccessPointId()) {
-            $node->appendChild($document->createElement('PublicAccessPointID', $this->getPublicAccessPointId()));
+            $node->appendChild($document->createElement('PublicAccessPointID', ($this->getPublicAccessPointId()) !== null ? htmlspecialchars($this->getPublicAccessPointId()) : null));
         }
 
         if ($this->getAccountNumber()) {
-            $node->appendChild($document->createElement('AccountNumber', $this->getAccountNumber()));
+            $node->appendChild($document->createElement('AccountNumber', ($this->getAccountNumber()) !== null ? htmlspecialchars($this->getAccountNumber()) : null));
         }
 
         return $node;

--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -267,26 +267,26 @@ class Address implements NodeInterface
 
         $node = $document->createElement('Address');
         if ($this->getAddressLine1()) {
-            $node->appendChild($document->createElement('AddressLine1', $this->getAddressLine1()));
+            $node->appendChild($document->createElement('AddressLine1', ($this->getAddressLine1()) !== null ? htmlspecialchars($this->getAddressLine1()) : null));
         }
 
         if ($this->getAddressLine2()) {
-            $node->appendChild($document->createElement('AddressLine2', $this->getAddressLine2()));
+            $node->appendChild($document->createElement('AddressLine2', ($this->getAddressLine2()) !== null ? htmlspecialchars($this->getAddressLine2()) : null));
         }
         if ($this->getAddressLine3()) {
-            $node->appendChild($document->createElement('AddressLine3', $this->getAddressLine3()));
+            $node->appendChild($document->createElement('AddressLine3', ($this->getAddressLine3()) !== null ? htmlspecialchars($this->getAddressLine3()) : null));
         }
         if ($this->getCity()) {
-            $node->appendChild($document->createElement('City', $this->getCity()));
+            $node->appendChild($document->createElement('City', ($this->getCity()) !== null ? htmlspecialchars($this->getCity()) : null));
         }
         if ($this->getStateProvinceCode()) {
-            $node->appendChild($document->createElement('StateProvinceCode', $this->getStateProvinceCode()));
+            $node->appendChild($document->createElement('StateProvinceCode', ($this->getStateProvinceCode()) !== null ? htmlspecialchars($this->getStateProvinceCode()) : null));
         }
         if ($this->getPostalCode()) {
-            $node->appendChild($document->createElement('PostalCode', $this->getPostalCode()));
+            $node->appendChild($document->createElement('PostalCode', ($this->getPostalCode()) !== null ? htmlspecialchars($this->getPostalCode()) : null));
         }
         if ($this->getCountryCode()) {
-            $node->appendChild($document->createElement('CountryCode', $this->getCountryCode()));
+            $node->appendChild($document->createElement('CountryCode', ($this->getCountryCode()) !== null ? htmlspecialchars($this->getCountryCode()) : null));
         }
         if ($this->getResidentialAddressIndicator()) {
             $node->appendChild($document->createElement('ResidentialAddressIndicator'));

--- a/src/Entity/AddressArtifactFormat.php
+++ b/src/Entity/AddressArtifactFormat.php
@@ -42,21 +42,21 @@ class AddressArtifactFormat extends Address
         for ($i = 1; $i <= 3; $i++) {
             $line = $this->{'getPoliticalDivision'.$i}();
             if ($line) {
-                $node->appendChild($document->createElement('PoliticalDivision'.$i, $line));
+                $node->appendChild($document->createElement('PoliticalDivision'.$i, ($line) !== null ? htmlspecialchars($line) : null));
             }
         }
 
         if ($this->getCountryCode()) {
-            $node->appendChild($document->createElement('CountryCode', $this->getCountryCode()));
+            $node->appendChild($document->createElement('CountryCode', ($this->getCountryCode()) !== null ? htmlspecialchars($this->getCountryCode()) : null));
         }
         if ($this->getCountry()) {
-            $node->appendChild($document->createElement('Country', $this->getCountry()));
+            $node->appendChild($document->createElement('Country', ($this->getCountry()) !== null ? htmlspecialchars($this->getCountry()) : null));
         }
         if ($this->getPostcodePrimaryHigh()) {
-            $node->appendChild($document->createElement('PostcodePrimaryHigh', $this->getPostcodePrimaryHigh()));
+            $node->appendChild($document->createElement('PostcodePrimaryHigh', ($this->getPostcodePrimaryHigh()) !== null ? htmlspecialchars($this->getPostcodePrimaryHigh()) : null));
         }
         if ($this->getPostcodePrimaryLow()) {
-            $node->appendChild($document->createElement('PostcodePrimaryLow', $this->getPostcodePrimaryLow()));
+            $node->appendChild($document->createElement('PostcodePrimaryLow', ($this->getPostcodePrimaryLow()) !== null ? htmlspecialchars($this->getPostcodePrimaryLow()) : null));
         }
 
         return $node;

--- a/src/Entity/AddressKeyFormat.php
+++ b/src/Entity/AddressKeyFormat.php
@@ -56,7 +56,7 @@ class AddressKeyFormat extends Address
         $node = $document->createElement('AddressKeyFormat');
 
         if ($this->getConsigneeName()) {
-            $node->appendChild($document->createElement('ConsigneeName', $this->getConsigneeName()));
+            $node->appendChild($document->createElement('ConsigneeName', ($this->getConsigneeName()) !== null ? htmlspecialchars($this->getConsigneeName()) : null));
         }
 
         for ($i = 1; $i <= 3; $i++) {
@@ -69,23 +69,23 @@ class AddressKeyFormat extends Address
         for ($i = 1; $i <= 3; $i++) {
             $line = $this->{'getPoliticalDivision'.$i}();
             if ($line) {
-                $node->appendChild($document->createElement('PoliticalDivision'.$i, $line));
+                $node->appendChild($document->createElement('PoliticalDivision'.$i, ($line) !== null ? htmlspecialchars($line) : null));
             }
         }
 
         if ($this->getPostcodePrimaryLow()) {
-            $node->appendChild($document->createElement('PostcodePrimaryLow', $this->getPostcodePrimaryLow()));
+            $node->appendChild($document->createElement('PostcodePrimaryLow', ($this->getPostcodePrimaryLow()) !== null ? htmlspecialchars($this->getPostcodePrimaryLow()) : null));
         }
         if ($this->getPostcodeExtendedLow()) {
-            $node->appendChild($document->createElement('PostcodeExtendedLow', $this->getPostcodeExtendedLow()));
+            $node->appendChild($document->createElement('PostcodeExtendedLow', ($this->getPostcodeExtendedLow()) !== null ? htmlspecialchars($this->getPostcodeExtendedLow()) : null));
         }
 
         if ($this->getCountryCode()) {
-            $node->appendChild($document->createElement('CountryCode', $this->getCountryCode()));
+            $node->appendChild($document->createElement('CountryCode', ($this->getCountryCode()) !== null ? htmlspecialchars($this->getCountryCode()) : null));
         }
 
         if ($this->getSingleLineAddress()) {
-            $node->appendChild($document->createElement('SingleLineAddress', $this->getSingleLineAddress()));
+            $node->appendChild($document->createElement('SingleLineAddress', ($this->getSingleLineAddress()) !== null ? htmlspecialchars($this->getSingleLineAddress()) : null));
         }
 
         return $node;

--- a/src/Entity/AlternateDeliveryAddress.php
+++ b/src/Entity/AlternateDeliveryAddress.php
@@ -30,11 +30,11 @@ class AlternateDeliveryAddress extends ShipTo
         $node = $document->createElement('AlternateDeliveryAddress');
 
         if ($this->getName()) {
-            $node->appendChild($document->createElement('Name', $this->getName()));
+            $node->appendChild($document->createElement('Name', ($this->getName()) !== null ? htmlspecialchars($this->getName()) : null));
         }
 
         if ($this->getUpsAccessPointId()) {
-            $node->appendChild($document->createElement('UPSAccessPointID', $this->getUpsAccessPointId()));
+            $node->appendChild($document->createElement('UPSAccessPointID', ($this->getUpsAccessPointId()) !== null ? htmlspecialchars($this->getUpsAccessPointId()) : null));
         }
 
         $address = $this->getAddress();

--- a/src/Entity/COD.php
+++ b/src/Entity/COD.php
@@ -57,11 +57,11 @@ class COD implements NodeInterface
         $node = $document->createElement('COD');
 
         if ($this->getCODCode()) {
-            $node->appendChild($document->createElement('CODCode', $this->getCODCode()));
+            $node->appendChild($document->createElement('CODCode', ($this->getCODCode()) !== null ? htmlspecialchars($this->getCODCode()) : null));
         }
 
         if ($this->getCODFundsCode()) {
-            $node->appendChild($document->createElement('CODFundsCode', $this->getCODFundsCode()));
+            $node->appendChild($document->createElement('CODFundsCode', ($this->getCODFundsCode()) !== null ? htmlspecialchars($this->getCODFundsCode()) : null));
         }
 
         if ($this->getCODAmount()) {

--- a/src/Entity/CODAmount.php
+++ b/src/Entity/CODAmount.php
@@ -35,10 +35,10 @@ class CODAmount implements NodeInterface
         }
         $node = $document->createElement('CODAmount');
         if ($this->CurrencyCode) {
-            $node->appendChild($document->createElement('CurrencyCode', $this->CurrencyCode));
+            $node->appendChild($document->createElement('CurrencyCode', ($this->CurrencyCode) !== null ? htmlspecialchars($this->CurrencyCode) : null));
         }
         if ($this->MonetaryValue) {
-            $node->appendChild($document->createElement('MonetaryValue', $this->MonetaryValue));
+            $node->appendChild($document->createElement('MonetaryValue', ($this->MonetaryValue) !== null ? htmlspecialchars($this->MonetaryValue) : null));
         }
         return $node;
     }

--- a/src/Entity/CustomerClassification.php
+++ b/src/Entity/CustomerClassification.php
@@ -32,7 +32,7 @@ class CustomerClassification implements NodeInterface
         }
 
         $node = $document->createElement('CustomerClassification');
-        $node->appendChild($document->createElement('Code', $this->getCode()));
+        $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
 
         return $node;
     }

--- a/src/Entity/DeliveryConfirmation.php
+++ b/src/Entity/DeliveryConfirmation.php
@@ -36,7 +36,7 @@ class DeliveryConfirmation implements NodeInterface
 
         $node = $document->createElement('DeliveryConfirmation');
 
-        $node->appendChild($document->createElement('DCISType', $this->getDcisType()));
+        $node->appendChild($document->createElement('DCISType', ($this->getDcisType()) !== null ? htmlspecialchars($this->getDcisType()) : null));
 
         return $node;
     }

--- a/src/Entity/DeliveryTimeInformation.php
+++ b/src/Entity/DeliveryTimeInformation.php
@@ -37,7 +37,7 @@ class DeliveryTimeInformation implements NodeInterface
         }
 
         $node = $document->createElement('DeliveryTimeInformation');
-        $node->appendChild($document->createElement('PackageBillType', $this->getPackageBillType()));
+        $node->appendChild($document->createElement('PackageBillType', ($this->getPackageBillType()) !== null ? htmlspecialchars($this->getPackageBillType()) : null));
 
         if ($this->getPickup() !== null) {
             $node->appendChild($this->getPickup()->toNode($document));

--- a/src/Entity/Dimensions.php
+++ b/src/Entity/Dimensions.php
@@ -61,9 +61,9 @@ class Dimensions implements NodeInterface
         }
 
         $node = $document->createElement('Dimensions');
-        $node->appendChild($document->createElement('Length', $this->getLength()));
-        $node->appendChild($document->createElement('Height', $this->getHeight()));
-        $node->appendChild($document->createElement('Width', $this->getWidth()));
+        $node->appendChild($document->createElement('Length', ($this->getLength()) !== null ? htmlspecialchars($this->getLength()) : null));
+        $node->appendChild($document->createElement('Height', ($this->getHeight()) !== null ? htmlspecialchars($this->getHeight()) : null));
+        $node->appendChild($document->createElement('Width', ($this->getWidth()) !== null ? htmlspecialchars($this->getWidth()) : null));
         $node->appendChild($this->getUnitOfMeasurement()->toNode($document));
 
         return $node;

--- a/src/Entity/Discount.php
+++ b/src/Entity/Discount.php
@@ -31,7 +31,7 @@ class Discount implements NodeInterface
         }
 
         $node = $document->createElement('Discount');
-        $node->appendChild($document->createElement('MonetaryValue', $this->getMonetaryValue()));
+        $node->appendChild($document->createElement('MonetaryValue', ($this->getMonetaryValue()) !== null ? htmlspecialchars($this->getMonetaryValue()) : null));
 
         return $node;
     }

--- a/src/Entity/EEIFilingOption.php
+++ b/src/Entity/EEIFilingOption.php
@@ -75,17 +75,17 @@ class EEIFilingOption implements NodeInterface
 
         $code = $this->getCode();
         if (isset($code)) {
-            $node->appendChild($document->createElement('Code', $code));
+            $node->appendChild($document->createElement('Code', ($code) !== null ? htmlspecialchars($code) : null));
         }
 
         $emailAddress = $this->getEmailAddress();
         if (isset($emailAddress)) {
-            $node->appendChild($document->createElement('EMailAdress', $emailAddress));
+            $node->appendChild($document->createElement('EMailAdress', ($emailAddress) !== null ? htmlspecialchars($emailAddress) : null));
         }
 
         $description = $this->getDescription();
         if (isset($description)) {
-            $node->appendChild($document->createElement('Description', $description));
+            $node->appendChild($document->createElement('Description', ($description) !== null ? htmlspecialchars($description) : null));
         }
 
         $upsFiled = $this->getUPSFiled();

--- a/src/Entity/EmailMessage.php
+++ b/src/Entity/EmailMessage.php
@@ -66,31 +66,31 @@ class EmailMessage implements NodeInterface
         $node = $document->createElement('EMailMessage');
 
         foreach ($this->getEmailAddresses() as $email) {
-            $node->appendChild($document->createElement('EMailAddress', $email));
+            $node->appendChild($document->createElement('EMailAddress', ($email) !== null ? htmlspecialchars($email) : null));
         }
 
         if ($this->getUndeliverableEmailAddress() !== null) {
-            $node->appendChild($document->createElement('UndeliverableEMailAddress', $this->getUndeliverableEmailAddress()));
+            $node->appendChild($document->createElement('UndeliverableEMailAddress', ($this->getUndeliverableEmailAddress()) !== null ? htmlspecialchars($this->getUndeliverableEmailAddress()) : null));
         }
 
         if ($this->getFromEmailAddress() !== null) {
-            $node->appendChild($document->createElement('FromEMailAddress', $this->getFromEmailAddress()));
+            $node->appendChild($document->createElement('FromEMailAddress', ($this->getFromEmailAddress()) !== null ? htmlspecialchars($this->getFromEmailAddress()) : null));
         }
 
         if ($this->getFromName() !== null) {
-            $node->appendChild($document->createElement('FromName', $this->getFromName()));
+            $node->appendChild($document->createElement('FromName', ($this->getFromName()) !== null ? htmlspecialchars($this->getFromName()) : null));
         }
 
         if ($this->getMemo() !== null) {
-            $node->appendChild($document->createElement('Memo', $this->getMemo()));
+            $node->appendChild($document->createElement('Memo', ($this->getMemo()) !== null ? htmlspecialchars($this->getMemo()) : null));
         }
 
         if ($this->getSubject() !== null) {
-            $node->appendChild($document->createElement('Subject', $this->getSubject()));
+            $node->appendChild($document->createElement('Subject', ($this->getSubject()) !== null ? htmlspecialchars($this->getSubject()) : null));
         }
 
         if ($this->getSubjectCode() !== null) {
-            $node->appendChild($document->createElement('SubjectCode', $this->getSubjectCode()));
+            $node->appendChild($document->createElement('SubjectCode', ($this->getSubjectCode()) !== null ? htmlspecialchars($this->getSubjectCode()) : null));
         }
 
         return $node;

--- a/src/Entity/FreightCharges.php
+++ b/src/Entity/FreightCharges.php
@@ -31,7 +31,7 @@ class FreightCharges implements NodeInterface
         }
 
         $node = $document->createElement('FreightCharges');
-        $node->appendChild($document->createElement('MonetaryValue', $this->getMonetaryValue()));
+        $node->appendChild($document->createElement('MonetaryValue', ($this->getMonetaryValue()) !== null ? htmlspecialchars($this->getMonetaryValue()) : null));
 
         return $node;
     }

--- a/src/Entity/GeoCode.php
+++ b/src/Entity/GeoCode.php
@@ -18,8 +18,8 @@ class GeoCode implements NodeInterface
 
         $node = $document->createElement('Geocode');
 
-        $node->appendChild($document->createElement('Latitude', $this->getLatitude()));
-        $node->appendChild($document->createElement('Longitude', $this->getLongitude()));
+        $node->appendChild($document->createElement('Latitude', ($this->getLatitude()) !== null ? htmlspecialchars($this->getLatitude()) : null));
+        $node->appendChild($document->createElement('Longitude', ($this->getLongitude()) !== null ? htmlspecialchars($this->getLongitude()) : null));
 
         return $node;
     }

--- a/src/Entity/HazMat.php
+++ b/src/Entity/HazMat.php
@@ -151,79 +151,79 @@ class HazMat implements NodeInterface
 
 
         if ($this->getPackagingTypeQuantity()) {
-            $node->appendChild($document->createElement('PackagingTypeQuantity', $this->getPackagingTypeQuantity()));
+            $node->appendChild($document->createElement('PackagingTypeQuantity', ($this->getPackagingTypeQuantity()) !== null ? htmlspecialchars($this->getPackagingTypeQuantity()) : null));
         }
         if ($this->getSubRiskClass()) {
-            $node->appendChild($document->createElement('SubRiskClass', $this->getSubRiskClass()));
+            $node->appendChild($document->createElement('SubRiskClass', ($this->getSubRiskClass()) !== null ? htmlspecialchars($this->getSubRiskClass()) : null));
         }
         if ($this->getAdrItemNumber()) {
-            $node->appendChild($document->createElement('aDRItemNumber', $this->getAdrItemNumber()));
+            $node->appendChild($document->createElement('aDRItemNumber', ($this->getAdrItemNumber()) !== null ? htmlspecialchars($this->getAdrItemNumber()) : null));
         }
         if ($this->getAdrPackingGroupLetter()) {
-            $node->appendChild($document->createElement('aDRPackingGroupLetter', $this->getAdrPackingGroupLetter()));
+            $node->appendChild($document->createElement('aDRPackingGroupLetter', ($this->getAdrPackingGroupLetter()) !== null ? htmlspecialchars($this->getAdrPackingGroupLetter()) : null));
         }
         if ($this->getTechnicalName()) {
-            $node->appendChild($document->createElement('TechnicalName', $this->getTechnicalName()));
+            $node->appendChild($document->createElement('TechnicalName', ($this->getTechnicalName()) !== null ? htmlspecialchars($this->getTechnicalName()) : null));
         }
         if ($this->getHazardLabelRequired()) {
-            $node->appendChild($document->createElement('HazardLabelRequired', $this->getHazardLabelRequired()));
+            $node->appendChild($document->createElement('HazardLabelRequired', ($this->getHazardLabelRequired()) !== null ? htmlspecialchars($this->getHazardLabelRequired()) : null));
         }
         if ($this->getReferenceNumber()) {
-            $node->appendChild($document->createElement('ReferenceNumber', $this->getReferenceNumber()));
+            $node->appendChild($document->createElement('ReferenceNumber', ($this->getReferenceNumber()) !== null ? htmlspecialchars($this->getReferenceNumber()) : null));
         }
         if ($this->getQuantity()) {
-            $node->appendChild($document->createElement('Quantity', $this->getQuantity()));
+            $node->appendChild($document->createElement('Quantity', ($this->getQuantity()) !== null ? htmlspecialchars($this->getQuantity()) : null));
         }
         if ($this->getClassDivisionNumber()) {
-            $node->appendChild($document->createElement('ClassDivisionNumber', $this->getClassDivisionNumber()));
+            $node->appendChild($document->createElement('ClassDivisionNumber', ($this->getClassDivisionNumber()) !== null ? htmlspecialchars($this->getClassDivisionNumber()) : null));
         }
         if ($this->getUom()) {
-            $node->appendChild($document->createElement('UOM', $this->getUom()));
+            $node->appendChild($document->createElement('UOM', ($this->getUom()) !== null ? htmlspecialchars($this->getUom()) : null));
         }
         if ($this->getPackagingType()) {
-            $node->appendChild($document->createElement('PackagingType', $this->getPackagingType()));
+            $node->appendChild($document->createElement('PackagingType', ($this->getPackagingType()) !== null ? htmlspecialchars($this->getPackagingType()) : null));
         }
         if ($this->getIdNumber()) {
-            $node->appendChild($document->createElement('IDNumber', $this->getIdNumber()));
+            $node->appendChild($document->createElement('IDNumber', ($this->getIdNumber()) !== null ? htmlspecialchars($this->getIdNumber()) : null));
         }
         if ($this->getProperShippingName()) {
-            $node->appendChild($document->createElement('ProperShippingName', $this->getProperShippingName()));
+            $node->appendChild($document->createElement('ProperShippingName', ($this->getProperShippingName()) !== null ? htmlspecialchars($this->getProperShippingName()) : null));
         }
         if ($this->getAdditionalDescription()) {
-            $node->appendChild($document->createElement('AdditionalDescription', $this->getAdditionalDescription()));
+            $node->appendChild($document->createElement('AdditionalDescription', ($this->getAdditionalDescription()) !== null ? htmlspecialchars($this->getAdditionalDescription()) : null));
         }
         if ($this->getPackagingGroupType()) {
-            $node->appendChild($document->createElement('PackagingGroupType', $this->getPackagingGroupType()));
+            $node->appendChild($document->createElement('PackagingGroupType', ($this->getPackagingGroupType()) !== null ? htmlspecialchars($this->getPackagingGroupType()) : null));
         }
         if ($this->getPackagingInstructionCode()) {
-            $node->appendChild($document->createElement('PackagingInstructionCode', $this->getPackagingInstructionCode()));
+            $node->appendChild($document->createElement('PackagingInstructionCode', ($this->getPackagingInstructionCode()) !== null ? htmlspecialchars($this->getPackagingInstructionCode()) : null));
         }
         if ($this->getEmergencyPhone()) {
-            $node->appendChild($document->createElement('EmergencyPhone', $this->getEmergencyPhone()));
+            $node->appendChild($document->createElement('EmergencyPhone', ($this->getEmergencyPhone()) !== null ? htmlspecialchars($this->getEmergencyPhone()) : null));
         }
         if ($this->getEmergencyContact()) {
-            $node->appendChild($document->createElement('EmergencyContact', $this->getEmergencyContact()));
+            $node->appendChild($document->createElement('EmergencyContact', ($this->getEmergencyContact()) !== null ? htmlspecialchars($this->getEmergencyContact()) : null));
         }
         if ($this->getReportableQuantity()) {
-            $node->appendChild($document->createElement('ReportableQuantity', $this->getReportableQuantity()));
+            $node->appendChild($document->createElement('ReportableQuantity', ($this->getReportableQuantity()) !== null ? htmlspecialchars($this->getReportableQuantity()) : null));
         }
         if ($this->getRegulationSet()) {
-            $node->appendChild($document->createElement('RegulationSet', $this->getRegulationSet()));
+            $node->appendChild($document->createElement('RegulationSet', ($this->getRegulationSet()) !== null ? htmlspecialchars($this->getRegulationSet()) : null));
         }
         if ($this->getTransportationMode()) {
-            $node->appendChild($document->createElement('TransportationMode', $this->getTransportationMode()));
+            $node->appendChild($document->createElement('TransportationMode', ($this->getTransportationMode()) !== null ? htmlspecialchars($this->getTransportationMode()) : null));
         }
         if ($this->getCommodityRegulatedLevelCode()) {
-            $node->appendChild($document->createElement('CommodityRegulatedLevelCode', $this->getCommodityRegulatedLevelCode()));
+            $node->appendChild($document->createElement('CommodityRegulatedLevelCode', ($this->getCommodityRegulatedLevelCode()) !== null ? htmlspecialchars($this->getCommodityRegulatedLevelCode()) : null));
         }
         if ($this->getTransportCategory()) {
-            $node->appendChild($document->createElement('TransportCategory', $this->getTransportCategory()));
+            $node->appendChild($document->createElement('TransportCategory', ($this->getTransportCategory()) !== null ? htmlspecialchars($this->getTransportCategory()) : null));
         }
         if ($this->getTunnelRestrictionCode()) {
-            $node->appendChild($document->createElement('TunnelRestrictionCode', $this->getTunnelRestrictionCode()));
+            $node->appendChild($document->createElement('TunnelRestrictionCode', ($this->getTunnelRestrictionCode()) !== null ? htmlspecialchars($this->getTunnelRestrictionCode()) : null));
         }
         if ($this->getChemicalRecordIdentifier()) {
-            $node->appendChild($document->createElement('ChemicalRecordIdentifier', $this->getChemicalRecordIdentifier()));
+            $node->appendChild($document->createElement('ChemicalRecordIdentifier', ($this->getChemicalRecordIdentifier()) !== null ? htmlspecialchars($this->getChemicalRecordIdentifier()) : null));
         }
 
         return $node;

--- a/src/Entity/HazMatPackageInformation.php
+++ b/src/Entity/HazMatPackageInformation.php
@@ -48,7 +48,7 @@ class HazMatPackageInformation implements NodeInterface
             $node->appendChild($document->createElement('OverPackedIndicator'));
         }
         if ($this->getQValue() !== null) {
-            $node->appendChild($document->createElement('QValue', $this->getQValue()));
+            $node->appendChild($document->createElement('QValue', ($this->getQValue()) !== null ? htmlspecialchars($this->getQValue()) : null));
         }
 
         return $node;

--- a/src/Entity/InsuredValue.php
+++ b/src/Entity/InsuredValue.php
@@ -47,8 +47,8 @@ class InsuredValue implements NodeInterface
         }
 
         $node = $document->createElement('InsuredValue');
-        $node->appendChild($document->createElement('CurrencyCode', $this->getCurrencyCode()));
-        $node->appendChild($document->createElement('MonetaryValue', $this->getMonetaryValue()));
+        $node->appendChild($document->createElement('CurrencyCode', ($this->getCurrencyCode()) !== null ? htmlspecialchars($this->getCurrencyCode()) : null));
+        $node->appendChild($document->createElement('MonetaryValue', ($this->getMonetaryValue()) !== null ? htmlspecialchars($this->getMonetaryValue()) : null));
 
         return $node;
     }

--- a/src/Entity/InternationalForms.php
+++ b/src/Entity/InternationalForms.php
@@ -309,31 +309,31 @@ class InternationalForms implements NodeInterface
         $node = $document->createElement('InternationalForms');
 
         foreach ($this->getTypes() as $type) {
-            $node->appendChild($document->createElement('FormType', $type));
+            $node->appendChild($document->createElement('FormType', ($type) !== null ? htmlspecialchars($type) : null));
         }
         if ($this->getInvoiceNumber() !== null) {
-            $node->appendChild($document->createElement('InvoiceNumber', $this->getInvoiceNumber()));
+            $node->appendChild($document->createElement('InvoiceNumber', ($this->getInvoiceNumber()) !== null ? htmlspecialchars($this->getInvoiceNumber()) : null));
         }
         if ($this->getInvoiceDate() !== null) {
-            $node->appendChild($document->createElement('InvoiceDate', $this->getInvoiceDate()->format('Ymd')));
+            $node->appendChild($document->createElement('InvoiceDate', ($this->getInvoiceDate()->format('Ymd')) !== null ? htmlspecialchars($this->getInvoiceDate()->format('Ymd')) : null));
         }
         if ($this->getPurchaseOrderNumber() !== null) {
-            $node->appendChild($document->createElement('PurchaseOrderNumber', $this->getPurchaseOrderNumber()));
+            $node->appendChild($document->createElement('PurchaseOrderNumber', ($this->getPurchaseOrderNumber()) !== null ? htmlspecialchars($this->getPurchaseOrderNumber()) : null));
         }
         if ($this->getTermsOfShipment() !== null) {
-            $node->appendChild($document->createElement('TermsOfShipment', $this->getTermsOfShipment()));
+            $node->appendChild($document->createElement('TermsOfShipment', ($this->getTermsOfShipment()) !== null ? htmlspecialchars($this->getTermsOfShipment()) : null));
         }
         if ($this->getReasonForExport() !== null) {
-            $node->appendChild($document->createElement('ReasonForExport', $this->getReasonForExport()));
+            $node->appendChild($document->createElement('ReasonForExport', ($this->getReasonForExport()) !== null ? htmlspecialchars($this->getReasonForExport()) : null));
         }
         if ($this->getComments() !== null) {
-            $node->appendChild($document->createElement('Comments', $this->getComments()));
+            $node->appendChild($document->createElement('Comments', ($this->getComments()) !== null ? htmlspecialchars($this->getComments()) : null));
         }
         if ($this->getDeclarationStatement() !== null) {
-            $node->appendChild($document->createElement('DeclarationStatement', $this->getDeclarationStatement()));
+            $node->appendChild($document->createElement('DeclarationStatement', ($this->getDeclarationStatement()) !== null ? htmlspecialchars($this->getDeclarationStatement()) : null));
         }
         if ($this->getCurrencyCode() !== null) {
-            $node->appendChild($document->createElement('CurrencyCode', $this->getCurrencyCode()));
+            $node->appendChild($document->createElement('CurrencyCode', ($this->getCurrencyCode()) !== null ? htmlspecialchars($this->getCurrencyCode()) : null));
         }
         if ($this->getDiscount() !== null) {
             $node->appendChild($this->getDiscount()->toNode($document));

--- a/src/Entity/InvoiceLineTotal.php
+++ b/src/Entity/InvoiceLineTotal.php
@@ -37,10 +37,10 @@ class InvoiceLineTotal implements NodeInterface
         $node = $document->createElement('InvoiceLineTotal');
 
         if ($this->getCurrencyCode()) {
-            $node->appendChild($document->createElement('CurrencyCode', $this->getCurrencyCode()));
+            $node->appendChild($document->createElement('CurrencyCode', ($this->getCurrencyCode()) !== null ? htmlspecialchars($this->getCurrencyCode()) : null));
         }
 
-        $node->appendChild($document->createElement('MonetaryValue', $this->getMonetaryValue()));
+        $node->appendChild($document->createElement('MonetaryValue', ($this->getMonetaryValue()) !== null ? htmlspecialchars($this->getMonetaryValue()) : null));
 
         return $node;
     }

--- a/src/Entity/LabelDelivery.php
+++ b/src/Entity/LabelDelivery.php
@@ -103,35 +103,35 @@ class LabelDelivery implements NodeInterface
         $node = $document->createElement('LabelDelivery');
 
         if (isset($this->LabelLinkIndicator)) {
-            $node->appendChild($document->createElement('LabelLinkIndicator', $this->LabelLinkIndicator));
+            $node->appendChild($document->createElement('LabelLinkIndicator', ($this->LabelLinkIndicator) !== null ? htmlspecialchars($this->LabelLinkIndicator) : null));
         }
 
         if (isset($this->EMailAddress)) {
-            $node->appendChild($document->createElement('EMailAddress', $this->EMailAddress));
+            $node->appendChild($document->createElement('EMailAddress', ($this->EMailAddress) !== null ? htmlspecialchars($this->EMailAddress) : null));
         }
 
         if (isset($this->UndeliverableEMailAddress)) {
-            $node->appendChild($document->createElement('UndeliverableEMailAddress', $this->UndeliverableEMailAddress));
+            $node->appendChild($document->createElement('UndeliverableEMailAddress', ($this->UndeliverableEMailAddress) !== null ? htmlspecialchars($this->UndeliverableEMailAddress) : null));
         }
 
         if (isset($this->FromEMailAddress)) {
-            $node->appendChild($document->createElement('FromEMailAddress', $this->FromEMailAddress));
+            $node->appendChild($document->createElement('FromEMailAddress', ($this->FromEMailAddress) !== null ? htmlspecialchars($this->FromEMailAddress) : null));
         }
 
         if (isset($this->FromName)) {
-            $node->appendChild($document->createElement('FromName', $this->FromName));
+            $node->appendChild($document->createElement('FromName', ($this->FromName) !== null ? htmlspecialchars($this->FromName) : null));
         }
 
         if (isset($this->Subject)) {
-            $node->appendChild($document->createElement('Subject', $this->Subject));
+            $node->appendChild($document->createElement('Subject', ($this->Subject) !== null ? htmlspecialchars($this->Subject) : null));
         }
 
         if (isset($this->Memo)) {
-            $node->appendChild($document->createElement('Memo', $this->Memo));
+            $node->appendChild($document->createElement('Memo', ($this->Memo) !== null ? htmlspecialchars($this->Memo) : null));
         }
 
         if (isset($this->SubjectCode)) {
-            $node->appendChild($document->createElement('SubjectCode', $this->SubjectCode));
+            $node->appendChild($document->createElement('SubjectCode', ($this->SubjectCode) !== null ? htmlspecialchars($this->SubjectCode) : null));
         }
 
         return $node;

--- a/src/Entity/LabelMethod.php
+++ b/src/Entity/LabelMethod.php
@@ -54,12 +54,12 @@ class LabelMethod implements NodeInterface
 
         $code = $this->getCode();
         if (isset($code)) {
-            $node->appendChild($document->createElement('Code', $code));
+            $node->appendChild($document->createElement('Code', ($code) !== null ? htmlspecialchars($code) : null));
         }
 
         $description = $this->getDescription();
         if (isset($description)) {
-            $node->appendChild($document->createElement('Description', $description));
+            $node->appendChild($document->createElement('Description', ($description) !== null ? htmlspecialchars($description) : null));
         }
 
         return $node;

--- a/src/Entity/Locale.php
+++ b/src/Entity/Locale.php
@@ -31,8 +31,8 @@ class Locale implements NodeInterface
 
         $node = $document->createElement('Locale');
 
-        $node->appendChild($document->createElement('Language', $this->getLanguage()));
-        $node->appendChild($document->createElement('Dialect', $this->getDialect()));
+        $node->appendChild($document->createElement('Language', ($this->getLanguage()) !== null ? htmlspecialchars($this->getLanguage()) : null));
+        $node->appendChild($document->createElement('Dialect', ($this->getDialect()) !== null ? htmlspecialchars($this->getDialect()) : null));
 
         return $node;
     }

--- a/src/Entity/LocationSearchCriteria.php
+++ b/src/Entity/LocationSearchCriteria.php
@@ -53,7 +53,7 @@ class LocationSearchCriteria implements NodeInterface
         }
 
         if ($this->getMaximumListSize()) {
-            $node->appendChild($document->createElement('MaximumListSize', $this->getMaximumListSize()));
+            $node->appendChild($document->createElement('MaximumListSize', ($this->getMaximumListSize()) !== null ? htmlspecialchars($this->getMaximumListSize()) : null));
         }
 
         return $node;

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -48,7 +48,7 @@ class Notification implements NodeInterface
 
         $node = $document->createElement('Notification');
 
-        $node->appendChild($document->createElement('NotificationCode', $this->getNotificationCode()));
+        $node->appendChild($document->createElement('NotificationCode', ($this->getNotificationCode()) !== null ? htmlspecialchars($this->getNotificationCode()) : null));
         if ($this->getEmailMessage() !== null) {
             $node->appendChild($this->emailMessage->toNode($document));
         }

--- a/src/Entity/OriginAddress.php
+++ b/src/Entity/OriginAddress.php
@@ -21,7 +21,7 @@ class OriginAddress implements NodeInterface
 
         $node = $document->createElement('OriginAddress');
         if ($this->getPhoneNumber()) {
-            $node->appendChild($document->createElement('AddressLine1', $this->getPhoneNumber()));
+            $node->appendChild($document->createElement('AddressLine1', ($this->getPhoneNumber()) !== null ? htmlspecialchars($this->getPhoneNumber()) : null));
         }
 
         if ($this->getGeoCode()) {
@@ -33,7 +33,7 @@ class OriginAddress implements NodeInterface
         }
 
         if ($this->getMaximumListSize()) {
-            $node->appendChild($document->createElement('MaximumListSize', $this->getMaximumListSize()));
+            $node->appendChild($document->createElement('MaximumListSize', ($this->getMaximumListSize()) !== null ? htmlspecialchars($this->getMaximumListSize()) : null));
         }
 
         return $node;

--- a/src/Entity/POA.php
+++ b/src/Entity/POA.php
@@ -51,12 +51,12 @@ class POA implements NodeInterface
 
         $code = $this->getCode();
         if (isset($code)) {
-            $node->appendChild($document->createElement('Code', $code));
+            $node->appendChild($document->createElement('Code', ($code) !== null ? htmlspecialchars($code) : null));
         }
 
         $description = $this->getDescription();
         if (isset($description)) {
-            $node->appendChild($document->createElement('Description', $description));
+            $node->appendChild($document->createElement('Description', ($description) !== null ? htmlspecialchars($description) : null));
         }
 
         return $node;

--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -143,7 +143,7 @@ class Package implements NodeInterface
         $packageNode = $document->createElement('Package');
 
         if ($this->getDescription()) {
-            $packageNode->appendChild($document->createElement('Description', $this->getDescription()));
+            $packageNode->appendChild($document->createElement('Description', ($this->getDescription()) !== null ? htmlspecialchars($this->getDescription()) : null));
         }
         $packageNode->appendChild($this->getPackagingType()->toNode($document));
         $packageNode->appendChild($this->getPackageWeight()->toNode($document));

--- a/src/Entity/PackageWeight.php
+++ b/src/Entity/PackageWeight.php
@@ -46,7 +46,7 @@ class PackageWeight implements NodeInterface
         }
 
         $node = $document->createElement('PackageWeight');
-        $node->appendChild($document->createElement('Weight', $this->getWeight()));
+        $node->appendChild($document->createElement('Weight', ($this->getWeight()) !== null ? htmlspecialchars($this->getWeight()) : null));
         $node->appendChild($this->getUnitOfMeasurement()->toNode($document));
 
         return $node;

--- a/src/Entity/PackagingType.php
+++ b/src/Entity/PackagingType.php
@@ -92,8 +92,8 @@ class PackagingType implements NodeInterface
         }
 
         $node = $document->createElement('PackagingType');
-        $node->appendChild($document->createElement('Code', $this->getCode()));
-        $node->appendChild($document->createElement('Description', $this->getDescription()));
+        $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
+        $node->appendChild($document->createElement('Description', ($this->getDescription()) !== null ? htmlspecialchars($this->getDescription()) : null));
 
         return $node;
     }

--- a/src/Entity/Pickup.php
+++ b/src/Entity/Pickup.php
@@ -48,8 +48,8 @@ class Pickup implements NodeInterface
         }
 
         $node = $document->createElement('Pickup');
-        $node->appendChild($document->createElement('Date', $this->getDate()));
-        $node->appendChild($document->createElement('Time', $this->getTime()));
+        $node->appendChild($document->createElement('Date', ($this->getDate()) !== null ? htmlspecialchars($this->getDate()) : null));
+        $node->appendChild($document->createElement('Time', ($this->getTime()) !== null ? htmlspecialchars($this->getTime()) : null));
 
         return $node;
     }

--- a/src/Entity/PickupType.php
+++ b/src/Entity/PickupType.php
@@ -42,8 +42,8 @@ class PickupType implements NodeInterface
         }
 
         $node = $document->createElement('PickupType');
-        $node->appendChild($document->createElement('Code', $this->getCode()));
-        $node->appendChild($document->createElement('Description', $this->getDescription()));
+        $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
+        $node->appendChild($document->createElement('Description', ($this->getDescription()) !== null ? htmlspecialchars($this->getDescription()) : null));
 
         return $node;
     }

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -82,20 +82,20 @@ class Product implements NodeInterface
         for ($i = 1; $i <= 3; $i++) {
             $desc = $this->{'getDescription'.$i}();
             if ($desc !== null) {
-                $node->appendChild($document->createElement('Description', $desc));
+                $node->appendChild($document->createElement('Description', ($desc) !== null ? htmlspecialchars($desc) : null));
             }
         }
         if ($this->getUnit() !== null) {
             $node->appendChild($this->getUnit()->toNode($document));
         }
         if ($this->getCommodityCode() !== null) {
-            $node->appendChild($document->createElement('CommodityCode', $this->getCommodityCode()));
+            $node->appendChild($document->createElement('CommodityCode', ($this->getCommodityCode()) !== null ? htmlspecialchars($this->getCommodityCode()) : null));
         }
         if ($this->getPartNumber() !== null) {
-            $node->appendChild($document->createElement('PartNumber', $this->getPartNumber()));
+            $node->appendChild($document->createElement('PartNumber', ($this->getPartNumber()) !== null ? htmlspecialchars($this->getPartNumber()) : null));
         }
         if ($this->getOriginCountryCode() !== null) {
-            $node->appendChild($document->createElement('OriginCountryCode', $this->getOriginCountryCode()));
+            $node->appendChild($document->createElement('OriginCountryCode', ($this->getOriginCountryCode()) !== null ? htmlspecialchars($this->getOriginCountryCode()) : null));
         }
 
         return $node;

--- a/src/Entity/ReferenceNumber.php
+++ b/src/Entity/ReferenceNumber.php
@@ -131,8 +131,8 @@ class ReferenceNumber implements NodeInterface
         if ($this->getBarCodeIndicator()) {
             $node->appendChild($document->createElement('BarCodeIndicator'));
         }
-        $node->appendChild($document->createElement('Code', $this->getCode()));
-        $node->appendChild($document->createElement('Value', $this->getValue()));
+        $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
+        $node->appendChild($document->createElement('Value', ($this->getValue()) !== null ? htmlspecialchars($this->getValue()) : null));
 
         return $node;
     }

--- a/src/Entity/ReturnService.php
+++ b/src/Entity/ReturnService.php
@@ -81,7 +81,7 @@ class ReturnService implements NodeInterface
         }
 
         $node = $document->createElement('ReturnService');
-        $node->appendChild($document->createElement('Code', $this->getCode()));
+        $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
 
         return $node;
     }

--- a/src/Entity/Service.php
+++ b/src/Entity/Service.php
@@ -156,8 +156,8 @@ class Service implements NodeInterface
         }
 
         $node = $document->createElement('Service');
-        $node->appendChild($document->createElement('Code', $this->getCode()));
-        $node->appendChild($document->createElement('Description', $this->getDescription()));
+        $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
+        $node->appendChild($document->createElement('Description', ($this->getDescription()) !== null ? htmlspecialchars($this->getDescription()) : null));
 
         return $node;
     }

--- a/src/Entity/ShipFrom.php
+++ b/src/Entity/ShipFrom.php
@@ -22,11 +22,11 @@ class ShipFrom extends Shipper implements NodeInterface
         $node = $document->createElement('ShipFrom');
 
         if ($this->getCompanyName()) {
-            $node->appendChild($document->createElement('CompanyName', $this->getCompanyName()));
+            $node->appendChild($document->createElement('CompanyName', ($this->getCompanyName()) !== null ? htmlspecialchars($this->getCompanyName()) : null));
         }
 
         if ($this->getAttentionName()) {
-            $node->appendChild($document->createElement('AttentionName', $this->getAttentionName()));
+            $node->appendChild($document->createElement('AttentionName', ($this->getAttentionName()) !== null ? htmlspecialchars($this->getAttentionName()) : null));
         }
 
         $address = $this->getAddress();

--- a/src/Entity/ShipTo.php
+++ b/src/Entity/ShipTo.php
@@ -142,8 +142,8 @@ class ShipTo implements NodeInterface
         }
 
         $node = $document->createElement('ShipTo');
-        $node->appendChild($document->createElement('CompanyName', $this->getCompanyName()));
-        $node->appendChild($document->createElement('AttentionName', $this->getAttentionName()));
+        $node->appendChild($document->createElement('CompanyName', ($this->getCompanyName()) !== null ? htmlspecialchars($this->getCompanyName()) : null));
+        $node->appendChild($document->createElement('AttentionName', ($this->getAttentionName()) !== null ? htmlspecialchars($this->getAttentionName()) : null));
 
         $address = $this->getAddress();
         if (isset($address)) {

--- a/src/Entity/ShipmentIndicationType.php
+++ b/src/Entity/ShipmentIndicationType.php
@@ -37,10 +37,10 @@ class ShipmentIndicationType implements NodeInterface
 
         $node = $document->createElement('ShipmentIndicationType');
 
-        $node->appendChild($document->createElement('Code', $this->getCode()));
+        $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
 
         if ($this->getDescription()) {
-            $node->appendChild($document->createElement('Description', $this->getDescription()));
+            $node->appendChild($document->createElement('Description', ($this->getDescription()) !== null ? htmlspecialchars($this->getDescription()) : null));
         }
 
         return $node;

--- a/src/Entity/ShipmentServiceOptions.php
+++ b/src/Entity/ShipmentServiceOptions.php
@@ -194,12 +194,12 @@ class ShipmentServiceOptions implements NodeInterface
             $labelDelivery = $this->getLabelDelivery();
             foreach ($labelDelivery as $key => $value) {
                 if ($key == 'LabelLinkIndicator') {
-                    $labelDeliveryNode->appendChild($document->createElement($key, $value));
+                    $labelDeliveryNode->appendChild($document->createElement($key, ($value) !== null ? htmlspecialchars($value) : null));
                 } elseif ($key == 'SubjectCode') {
                     $SubjectNode = $emailMessageNode->appendChild($document->createElement('Subject'));
-                    $SubjectNode->appendChild($document->createElement($key, $value));
+                    $SubjectNode->appendChild($document->createElement($key, ($value) !== null ? htmlspecialchars($value) : null));
                 } else {
-                    $emailMessageNode->appendChild($document->createElement($key, $value));
+                    $emailMessageNode->appendChild($document->createElement($key, ($value) !== null ? htmlspecialchars($value) : null));
                 }
             }
         }

--- a/src/Entity/ShipmentTotalWeight.php
+++ b/src/Entity/ShipmentTotalWeight.php
@@ -47,7 +47,7 @@ class ShipmentTotalWeight implements NodeInterface
             $node->appendChild($this->getUnitOfMeasurement()->toNode($document));
         }
 
-        $node->appendChild($document->createElement('Weight', $this->getWeight()));
+        $node->appendChild($document->createElement('Weight', ($this->getWeight()) !== null ? htmlspecialchars($this->getWeight()) : null));
         
         return $node;
     }

--- a/src/Entity/ShipmentWeight.php
+++ b/src/Entity/ShipmentWeight.php
@@ -37,7 +37,7 @@ class ShipmentWeight implements NodeInterface
         }
 
         $node = $document->createElement('ShipmentWeight');
-        $node->appendChild($document->createElement('Weight', $this->getWeight()));
+        $node->appendChild($document->createElement('Weight', ($this->getWeight()) !== null ? htmlspecialchars($this->getWeight()) : null));
         $node->appendChild($this->getUnitOfMeasurement()->toNode($document));
 
         return $node;

--- a/src/Entity/Shipper.php
+++ b/src/Entity/Shipper.php
@@ -114,12 +114,12 @@ class Shipper implements NodeInterface
 
         $shipperName = $this->getName();
         if (isset($shipperName)) {
-            $node->appendChild($document->createElement('Name', $shipperName));
+            $node->appendChild($document->createElement('Name', ($shipperName) !== null ? htmlspecialchars($shipperName) : null));
         }
 
         $shipperNumber = $this->getShipperNumber();
         if (isset($shipperNumber)) {
-            $node->appendChild($document->createElement('ShipperNumber', $shipperNumber));
+            $node->appendChild($document->createElement('ShipperNumber', ($shipperNumber) !== null ? htmlspecialchars($shipperNumber) : null));
         }
 
         $address = $this->getAddress();

--- a/src/Entity/ShipperFiled.php
+++ b/src/Entity/ShipperFiled.php
@@ -70,22 +70,22 @@ class ShipperFiled implements NodeInterface
 
         $code = $this->getCode();
         if (isset($code)) {
-            $node->appendChild($document->createElement('Code', $code));
+            $node->appendChild($document->createElement('Code', ($code) !== null ? htmlspecialchars($code) : null));
         }
 
         $description = $this->getDescription();
         if (isset($description)) {
-            $node->appendChild($document->createElement('Description', $description));
+            $node->appendChild($document->createElement('Description', ($description) !== null ? htmlspecialchars($description) : null));
         }
 
         $preDepartureITNNumber = $this->getPreDepartureITNNumber();
         if (isset($code)) {
-            $node->appendChild($document->createElement('PreDepartureITNNumber', $preDepartureITNNumber));
+            $node->appendChild($document->createElement('PreDepartureITNNumber', ($preDepartureITNNumber) !== null ? htmlspecialchars($preDepartureITNNumber) : null));
         }
 
         $exemptionLegend = $this->getExemptionLegend();
         if (isset($exemptionLegend)) {
-            $node->appendChild($document->createElement('ExemptionLegend', $exemptionLegend));
+            $node->appendChild($document->createElement('ExemptionLegend', ($exemptionLegend) !== null ? htmlspecialchars($exemptionLegend) : null));
         }
 
         return $node;

--- a/src/Entity/Tradeability/FreightCharges.php
+++ b/src/Entity/Tradeability/FreightCharges.php
@@ -32,8 +32,8 @@ class FreightCharges extends \Ups\Entity\FreightCharges
         }
 
         $node = $document->createElement('FreightCharges');
-        $node->appendChild($document->createElement('MonetaryValue', $this->getMonetaryValue()));
-        $node->appendChild($document->createElement('CurrencyCode', $this->getCurrencyCode()));
+        $node->appendChild($document->createElement('MonetaryValue', ($this->getMonetaryValue()) !== null ? htmlspecialchars($this->getMonetaryValue()) : null));
+        $node->appendChild($document->createElement('CurrencyCode', ($this->getCurrencyCode()) !== null ? htmlspecialchars($this->getCurrencyCode()) : null));
 
         return $node;
     }

--- a/src/Entity/Tradeability/Product.php
+++ b/src/Entity/Tradeability/Product.php
@@ -78,24 +78,25 @@ class Product implements NodeInterface
 
         // Optional
         if ($this->getProductName() !== null) {
-            $node->appendChild($document->createElement('ProductName', $this->getProductName()));
+            $node->appendChild($document->createElement('ProductName', ($this->getProductName()) !== null ? htmlspecialchars($this->getProductName()) : null));
         }
         if ($this->getProductDescription() !== null) {
-            $node->appendChild($document->createElement('ProductDescription', $this->getProductDescription()));
+            $node->appendChild($document->createElement('ProductDescription', ($this->getProductDescription()) !== null ? htmlspecialchars($this->getProductDescription()) : null));
         }
         if ($this->getProductCountryCodeOfOrigin() !== null) {
             $node->appendChild(
                 $document->createElement(
                     'ProductCountryCodeOfOrigin',
-                    $this->getProductCountryCodeOfOrigin()
-                )
+                    ($this->getProductCountryCodeOfOrigin()
+                ) !== null ? htmlspecialchars($this->getProductCountryCodeOfOrigin()
+                ) : null)
             );
         }
         if ($this->getWeight() instanceof Weight) {
             $node->appendChild($this->getWeight()->toNode($document));
         }
         if ($this->getTariffCodeAlert() !== null) {
-            $node->appendChild($document->createElement('TariffCodeAlert', $this->getTariffCodeAlert()));
+            $node->appendChild($document->createElement('TariffCodeAlert', ($this->getTariffCodeAlert()) !== null ? htmlspecialchars($this->getTariffCodeAlert()) : null));
         }
 
         return $node;

--- a/src/Entity/Tradeability/Quantity.php
+++ b/src/Entity/Tradeability/Quantity.php
@@ -36,7 +36,7 @@ class Quantity implements NodeInterface
         $node = $document->createElement('Quantity');
 
         // Required
-        $node->appendChild($document->createElement('Value', $this->getValue()));
+        $node->appendChild($document->createElement('Value', ($this->getValue()) !== null ? htmlspecialchars($this->getValue()) : null));
 
         // Optional
         if ($this->getUnitOfMeasurement() instanceof UnitOfMeasurement) {

--- a/src/Entity/Tradeability/Shipment.php
+++ b/src/Entity/Tradeability/Shipment.php
@@ -86,37 +86,39 @@ class Shipment implements NodeInterface
         }
 
         // Then the required values
-        $node->appendChild($document->createElement('OriginCountryCode', $this->getOriginCountryCode()));
-        $node->appendChild($document->createElement('DestinationCountryCode', $this->getDestinationCountryCode()));
+        $node->appendChild($document->createElement('OriginCountryCode', ($this->getOriginCountryCode()) !== null ? htmlspecialchars($this->getOriginCountryCode()) : null));
+        $node->appendChild($document->createElement('DestinationCountryCode', ($this->getDestinationCountryCode()) !== null ? htmlspecialchars($this->getDestinationCountryCode()) : null));
 
         // Then the optional values
         if ($this->getOriginStateProvinceCode() !== null) {
             $node->appendChild(
                 $document->createElement(
                     'OriginStateProvinceCode',
-                    $this->getOriginStateProvinceCode()
-                )
+                    ($this->getOriginStateProvinceCode()
+                ) !== null ? htmlspecialchars($this->getOriginStateProvinceCode()
+                ) : null)
             );
         }
         if ($this->getDestinationStateProvinceCode() !== null) {
             $node->appendChild(
                 $document->createElement(
                     'DestinationStateProvinceCode',
-                    $this->getDestinationStateProvinceCode()
-                )
+                    ($this->getDestinationStateProvinceCode()
+                ) !== null ? htmlspecialchars($this->getDestinationStateProvinceCode()
+                ) : null)
             );
         }
         if ($this->getTransportationMode() !== null) {
-            $node->appendChild($document->createElement('TransportationMode', $this->getTransportationMode()));
+            $node->appendChild($document->createElement('TransportationMode', ($this->getTransportationMode()) !== null ? htmlspecialchars($this->getTransportationMode()) : null));
         }
         if ($this->getResultCurrencyCode() !== null) {
-            $node->appendChild($document->createElement('ResultCurrencyCode', $this->getResultCurrencyCode()));
+            $node->appendChild($document->createElement('ResultCurrencyCode', ($this->getResultCurrencyCode()) !== null ? htmlspecialchars($this->getResultCurrencyCode()) : null));
         }
         if ($this->getTariffCodeAlert() !== null) {
-            $node->appendChild($document->createElement('TariffCodeAlert', $this->getTariffCodeAlert()));
+            $node->appendChild($document->createElement('TariffCodeAlert', ($this->getTariffCodeAlert()) !== null ? htmlspecialchars($this->getTariffCodeAlert()) : null));
         }
         if ($this->getTransactionReferenceId() !== null) {
-            $node->appendChild($document->createElement('TransactionReferenceID', $this->getTransactionReferenceId()));
+            $node->appendChild($document->createElement('TransactionReferenceID', ($this->getTransactionReferenceId()) !== null ? htmlspecialchars($this->getTransactionReferenceId()) : null));
         }
 
         // Then products array

--- a/src/Entity/Tradeability/TariffInfo.php
+++ b/src/Entity/Tradeability/TariffInfo.php
@@ -50,17 +50,17 @@ class TariffInfo implements NodeInterface
         $node = $document->createElement('TariffInfo');
 
         // Required
-        $node->appendChild($document->createElement('TariffCode', $this->getTariffCode()));
+        $node->appendChild($document->createElement('TariffCode', ($this->getTariffCode()) !== null ? htmlspecialchars($this->getTariffCode()) : null));
 
         // Optional
         if ($this->getDetailId() !== null) {
-            $node->appendChild($document->createElement('DetailId', $this->getDetailId()));
+            $node->appendChild($document->createElement('DetailId', ($this->getDetailId()) !== null ? htmlspecialchars($this->getDetailId()) : null));
         }
         if ($this->getSecondaryTariffCode() !== null) {
-            $node->appendChild($document->createElement('SecondaryTariffCode', $this->getSecondaryTariffCode()));
+            $node->appendChild($document->createElement('SecondaryTariffCode', ($this->getSecondaryTariffCode()) !== null ? htmlspecialchars($this->getSecondaryTariffCode()) : null));
         }
         if ($this->getSecondaryDetailId() !== null) {
-            $node->appendChild($document->createElement('SecondaryDetailId', $this->getSecondaryDetailId()));
+            $node->appendChild($document->createElement('SecondaryDetailId', ($this->getSecondaryDetailId()) !== null ? htmlspecialchars($this->getSecondaryDetailId()) : null));
         }
 
         return $node;

--- a/src/Entity/Tradeability/UnitOfMeasurement.php
+++ b/src/Entity/Tradeability/UnitOfMeasurement.php
@@ -20,10 +20,10 @@ class UnitOfMeasurement extends \Ups\Entity\UnitOfMeasurement
     {
         if (null !== $document) {
             $node = $document->createElement('UnitOfMeasure');
-            $node->appendChild($document->createElement('UnitCode', $this->getCode()));
+            $node->appendChild($document->createElement('UnitCode', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
 
             if ($this->getDescription() !== null) {
-                $node->appendChild($document->createElement('UnitDescription', $this->getDescription()));
+                $node->appendChild($document->createElement('UnitDescription', ($this->getDescription()) !== null ? htmlspecialchars($this->getDescription()) : null));
             }
 
             return $node;

--- a/src/Entity/Tradeability/UnitPrice.php
+++ b/src/Entity/Tradeability/UnitPrice.php
@@ -36,11 +36,11 @@ class UnitPrice implements NodeInterface
         $node = $document->createElement('UnitPrice');
 
         // Required
-        $node->appendChild($document->createElement('MonetaryValue', $this->getMonetaryValue()));
+        $node->appendChild($document->createElement('MonetaryValue', ($this->getMonetaryValue()) !== null ? htmlspecialchars($this->getMonetaryValue()) : null));
 
         // Optional
         if ($this->getCurrencyCode() !== null) {
-            $node->appendChild($document->createElement('CurrencyCode', $this->getCurrencyCode()));
+            $node->appendChild($document->createElement('CurrencyCode', ($this->getCurrencyCode()) !== null ? htmlspecialchars($this->getCurrencyCode()) : null));
         }
 
         return $node;

--- a/src/Entity/Tradeability/Weight.php
+++ b/src/Entity/Tradeability/Weight.php
@@ -36,7 +36,7 @@ class Weight implements NodeInterface
         $node = $document->createElement('Weight');
 
         // Required
-        $node->appendChild($document->createElement('Value', $this->getValue()));
+        $node->appendChild($document->createElement('Value', ($this->getValue()) !== null ? htmlspecialchars($this->getValue()) : null));
 
         // Optional
         if ($this->getUnitOfMeasurement() instanceof UnitOfMeasurement) {

--- a/src/Entity/Translate.php
+++ b/src/Entity/Translate.php
@@ -79,18 +79,18 @@ class Translate implements NodeInterface
 
         $node = $document->createElement('Translate');
 
-        $node->appendChild($document->createElement('LanguageCode', $this->getLanguageCode()));
+        $node->appendChild($document->createElement('LanguageCode', ($this->getLanguageCode()) !== null ? htmlspecialchars($this->getLanguageCode()) : null));
 
         if ($this->getCode()) {
-            $node->appendChild($document->createElement('Code', $this->getCode()));
+            $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
         }
 
         if ($this->getDialectCode()) {
-            $node->appendChild($document->createElement('DialectCode', $this->getDialectCode()));
+            $node->appendChild($document->createElement('DialectCode', ($this->getDialectCode()) !== null ? htmlspecialchars($this->getDialectCode()) : null));
         }
 
         if ($this->getLocale()) {
-            $node->appendChild($document->createElement('Locale', $this->getLocale()));
+            $node->appendChild($document->createElement('Locale', ($this->getLocale()) !== null ? htmlspecialchars($this->getLocale()) : null));
         }
 
         return $node;

--- a/src/Entity/Unit.php
+++ b/src/Entity/Unit.php
@@ -56,8 +56,8 @@ class Unit implements NodeInterface
         }
 
         $node = $document->createElement('Unit');
-        $node->appendChild($document->createElement('Number', $this->getNumber()));
-        $node->appendChild($document->createElement('Value', $this->getValue()));
+        $node->appendChild($document->createElement('Number', ($this->getNumber()) !== null ? htmlspecialchars($this->getNumber()) : null));
+        $node->appendChild($document->createElement('Value', ($this->getValue()) !== null ? htmlspecialchars($this->getValue()) : null));
         if ($this->getUnitOfMeasurement() !== null) {
             $node->appendChild($this->getUnitOfMeasurement()->toNode($document));
         }

--- a/src/Entity/UnitOfMeasurement.php
+++ b/src/Entity/UnitOfMeasurement.php
@@ -101,8 +101,8 @@ class UnitOfMeasurement implements NodeInterface
     {
         if (null !== $document) {
             $node = $document->createElement('UnitOfMeasurement');
-            $node->appendChild($document->createElement('Code', $this->getCode()));
-            $node->appendChild($document->createElement('Description', $this->getDescription()));
+            $node->appendChild($document->createElement('Code', ($this->getCode()) !== null ? htmlspecialchars($this->getCode()) : null));
+            $node->appendChild($document->createElement('Description', ($this->getDescription()) !== null ? htmlspecialchars($this->getDescription()) : null));
 
             return $node;
         }

--- a/src/Entity/VendorInfo.php
+++ b/src/Entity/VendorInfo.php
@@ -54,14 +54,14 @@ class VendorInfo implements NodeInterface
 
         $node = $document->createElement('VendorInfo');
         if ($this->getVendorCollectIDTypeCode()) {
-            $node->appendChild($document->createElement('VendorCollectIDTypeCode', $this->getVendorCollectIDTypeCode()));
+            $node->appendChild($document->createElement('VendorCollectIDTypeCode', ($this->getVendorCollectIDTypeCode()) !== null ? htmlspecialchars($this->getVendorCollectIDTypeCode()) : null));
         }
 
         if ($this->getVendorCollectIDNumber()) {
-            $node->appendChild($document->createElement('VendorCollectIDNumber', $this->getVendorCollectIDNumber()));
+            $node->appendChild($document->createElement('VendorCollectIDNumber', ($this->getVendorCollectIDNumber()) !== null ? htmlspecialchars($this->getVendorCollectIDNumber()) : null));
         }
         if ($this->getConsigneeType()) {
-            $node->appendChild($document->createElement('ConsigneeType', $this->getConsigneeType()));
+            $node->appendChild($document->createElement('ConsigneeType', ($this->getConsigneeType()) !== null ? htmlspecialchars($this->getConsigneeType()) : null));
         }
 
         return $node;

--- a/src/LabelRecovery.php
+++ b/src/LabelRecovery.php
@@ -78,16 +78,16 @@ class LabelRecovery extends Ups
 
         $labelSpecificationNode = $trackRequest->appendChild($xml->createElement('LabelSpecification'));
         if (isset($labelRecoveryRequest->LabelSpecification)) {
-            $labelSpecificationNode->appendChild($xml->createElement('HTTPUserAgent', $labelRecoveryRequest->LabelSpecification->HTTPUserAgent));
+            $labelSpecificationNode->appendChild($xml->createElement('HTTPUserAgent', ($labelRecoveryRequest->LabelSpecification->HTTPUserAgent) !== null ? htmlspecialchars($labelRecoveryRequest->LabelSpecification->HTTPUserAgent) : null));
             $labelImageFormatNode = $labelSpecificationNode->appendChild($xml->createElement('LabelImageFormat'));
-            $labelImageFormatNode->appendChild($xml->createElement('Code', $labelRecoveryRequest->LabelSpecification->LabelImageFormat->Code));
+            $labelImageFormatNode->appendChild($xml->createElement('Code', ($labelRecoveryRequest->LabelSpecification->LabelImageFormat->Code) !== null ? htmlspecialchars($labelRecoveryRequest->LabelSpecification->LabelImageFormat->Code) : null));
         }
 
         if (isset($labelRecoveryRequest->Translate)) {
             $translateNode = $trackRequest->appendChild($xml->createElement('Translate'));
-            $translateNode->appendChild($xml->createElement('LanguageCode', $labelRecoveryRequest->Translate->LanguageCode));
-            $translateNode->appendChild($xml->createElement('DialectCode', $labelRecoveryRequest->Translate->DialectCode));
-            $translateNode->appendChild($xml->createElement('Code', $labelRecoveryRequest->Translate->Code));
+            $translateNode->appendChild($xml->createElement('LanguageCode', ($labelRecoveryRequest->Translate->LanguageCode) !== null ? htmlspecialchars($labelRecoveryRequest->Translate->LanguageCode) : null));
+            $translateNode->appendChild($xml->createElement('DialectCode', ($labelRecoveryRequest->Translate->DialectCode) !== null ? htmlspecialchars($labelRecoveryRequest->Translate->DialectCode) : null));
+            $translateNode->appendChild($xml->createElement('Code', ($labelRecoveryRequest->Translate->Code) !== null ? htmlspecialchars($labelRecoveryRequest->Translate->Code) : null));
         }
 
         if (isset($labelRecoveryRequest->LabelLinkIndicator)) {
@@ -96,16 +96,16 @@ class LabelRecovery extends Ups
         }
 
         if (isset($labelRecoveryRequest->TrackingNumber)) {
-            $trackRequest->appendChild($xml->createElement('TrackingNumber', $labelRecoveryRequest->TrackingNumber));
+            $trackRequest->appendChild($xml->createElement('TrackingNumber', ($labelRecoveryRequest->TrackingNumber) !== null ? htmlspecialchars($labelRecoveryRequest->TrackingNumber) : null));
         }
 
         if (isset($labelRecoveryRequest->ReferenceNumber)) {
             $referenceNumberNode = $trackRequest->appendChild($xml->createElement('ReferenceNumber'));
-            $referenceNumberNode->appendChild($xml->createElement('Value', $labelRecoveryRequest->ReferenceNumber->getValue()));
+            $referenceNumberNode->appendChild($xml->createElement('Value', ($labelRecoveryRequest->ReferenceNumber->getValue()) !== null ? htmlspecialchars($labelRecoveryRequest->ReferenceNumber->getValue()) : null));
         }
 
         if (isset($labelRecoveryRequest->ShipperNumber)) {
-            $trackRequest->appendChild($xml->createElement('ShipperNumber', $labelRecoveryRequest->ShipperNumber));
+            $trackRequest->appendChild($xml->createElement('ShipperNumber', ($labelRecoveryRequest->ShipperNumber) !== null ? htmlspecialchars($labelRecoveryRequest->ShipperNumber) : null));
         }
 
         return $xml->saveXML();

--- a/src/Locator.php
+++ b/src/Locator.php
@@ -103,7 +103,7 @@ class Locator extends Ups
         $request->appendChild($node);
 
         $request->appendChild($xml->createElement('RequestAction', 'Locator'));
-        $request->appendChild($xml->createElement('RequestOption', $requestOption));
+        $request->appendChild($xml->createElement('RequestOption', ($requestOption) !== null ? htmlspecialchars($requestOption) : null));
 
         // Origin Address
         $trackRequest->appendChild($locatorRequest->getOriginAddress()->toNode($xml));

--- a/src/QuantumView.php
+++ b/src/QuantumView.php
@@ -149,24 +149,24 @@ class QuantumView extends Ups
 
             // Subscription name
             if (null !== $this->name) {
-                $subscriptionRequest->appendChild($xml->createElement('Name', $this->name));
+                $subscriptionRequest->appendChild($xml->createElement('Name', ($this->name) !== null ? htmlspecialchars($this->name) : null));
             }
 
             // Date Time Range
             if (null !== $this->beginDateTime) {
                 $dateTimeRange = $subscriptionRequest->appendChild($xml->createElement('DateTimeRange'));
-                $dateTimeRange->appendChild($xml->createElement('BeginDateTime', $this->beginDateTime));
-                $dateTimeRange->appendChild($xml->createElement('EndDateTime', $this->endDateTime));
+                $dateTimeRange->appendChild($xml->createElement('BeginDateTime', ($this->beginDateTime) !== null ? htmlspecialchars($this->beginDateTime) : null));
+                $dateTimeRange->appendChild($xml->createElement('EndDateTime', ($this->endDateTime) !== null ? htmlspecialchars($this->endDateTime) : null));
 
             // File name
             } elseif (null !== $this->fileName) {
-                $subscriptionRequest->appendChild($xml->createElement('FileName', $this->fileName));
+                $subscriptionRequest->appendChild($xml->createElement('FileName', ($this->fileName) !== null ? htmlspecialchars($this->fileName) : null));
             }
         }
 
         // Create the Bookmark element
         if (null !== $this->bookmark) {
-            $quantumViewRequest->appendChild($xml->createElement('Bookmark', $this->bookmark));
+            $quantumViewRequest->appendChild($xml->createElement('Bookmark', ($this->bookmark) !== null ? htmlspecialchars($this->bookmark) : null));
         }
 
         // Create the Request element

--- a/src/Rate.php
+++ b/src/Rate.php
@@ -130,7 +130,7 @@ class Rate extends Ups
         $request->appendChild($node);
 
         $request->appendChild($xml->createElement('RequestAction', 'Rate'));
-        $request->appendChild($xml->createElement('RequestOption', $this->requestOption));
+        $request->appendChild($xml->createElement('RequestOption', ($this->requestOption) !== null ? htmlspecialchars($this->requestOption) : null));
 
         $trackRequest->appendChild($rateRequest->getPickupType()->toNode($document));
 

--- a/src/Shipping.php
+++ b/src/Shipping.php
@@ -124,20 +124,20 @@ class Shipping extends Ups
         $request->appendChild($node);
 
         $request->appendChild($xml->createElement('RequestAction', 'ShipConfirm'));
-        $request->appendChild($xml->createElement('RequestOption', $validation ?: 'nonvalidate'));
+        $request->appendChild($xml->createElement('RequestOption', ($validation ?: 'nonvalidate') !== null ? htmlspecialchars($validation ?: 'nonvalidate') : null));
 
         // Page 47
         $shipmentNode = $container->appendChild($xml->createElement('Shipment'));
 
         if ($shipment->getDescription()) {
-            $shipmentNode->appendChild($xml->createElement('Description', $shipment->getDescription()));
+            $shipmentNode->appendChild($xml->createElement('Description', ($shipment->getDescription()) !== null ? htmlspecialchars($shipment->getDescription()) : null));
         }
 
         $returnService = $shipment->getReturnService();
         if (isset($returnService)) {
             $node = $shipmentNode->appendChild($xml->createElement('ReturnService'));
 
-            $node->appendChild($xml->createElement('Code', $returnService->getCode()));
+            $node->appendChild($xml->createElement('Code', ($returnService->getCode()) !== null ? htmlspecialchars($returnService->getCode()) : null));
         }
 
         if ($shipment->getDocumentsOnly()) {
@@ -146,54 +146,54 @@ class Shipping extends Ups
 
         $shipperNode = $shipmentNode->appendChild($xml->createElement('Shipper'));
 
-        $shipperNode->appendChild($xml->createElement('Name', $shipment->getShipper()->getName()));
+        $shipperNode->appendChild($xml->createElement('Name', ($shipment->getShipper()->getName()) !== null ? htmlspecialchars($shipment->getShipper()->getName()) : null));
 
         if ($shipment->getShipper()->getAttentionName()) {
-            $shipperNode->appendChild($xml->createElement('AttentionName', $shipment->getShipper()->getAttentionName()));
+            $shipperNode->appendChild($xml->createElement('AttentionName', ($shipment->getShipper()->getAttentionName()) !== null ? htmlspecialchars($shipment->getShipper()->getAttentionName()) : null));
         }
 
         if ($shipment->getShipper()->getCompanyName()) {
-            $shipperNode->appendChild($xml->createElement('CompanyDisplayableName', $shipment->getShipper()->getCompanyName()));
+            $shipperNode->appendChild($xml->createElement('CompanyDisplayableName', ($shipment->getShipper()->getCompanyName()) !== null ? htmlspecialchars($shipment->getShipper()->getCompanyName()) : null));
         }
 
-        $shipperNode->appendChild($xml->createElement('ShipperNumber', $shipment->getShipper()->getShipperNumber()));
+        $shipperNode->appendChild($xml->createElement('ShipperNumber', ($shipment->getShipper()->getShipperNumber()) !== null ? htmlspecialchars($shipment->getShipper()->getShipperNumber()) : null));
 
         if ($shipment->getShipper()->getTaxIdentificationNumber()) {
-            $shipperNode->appendChild($xml->createElement('TaxIdentificationNumber', $shipment->getShipper()->getTaxIdentificationNumber()));
+            $shipperNode->appendChild($xml->createElement('TaxIdentificationNumber', ($shipment->getShipper()->getTaxIdentificationNumber()) !== null ? htmlspecialchars($shipment->getShipper()->getTaxIdentificationNumber()) : null));
         }
 
         if ($shipment->getShipper()->getPhoneNumber()) {
-            $shipperNode->appendChild($xml->createElement('PhoneNumber', $shipment->getShipper()->getPhoneNumber()));
+            $shipperNode->appendChild($xml->createElement('PhoneNumber', ($shipment->getShipper()->getPhoneNumber()) !== null ? htmlspecialchars($shipment->getShipper()->getPhoneNumber()) : null));
         }
 
         if ($shipment->getShipper()->getFaxNumber()) {
-            $shipperNode->appendChild($xml->createElement('FaxNumber', $shipment->getShipper()->getFaxNumber()));
+            $shipperNode->appendChild($xml->createElement('FaxNumber', ($shipment->getShipper()->getFaxNumber()) !== null ? htmlspecialchars($shipment->getShipper()->getFaxNumber()) : null));
         }
 
         if ($shipment->getShipper()->getEMailAddress()) {
-            $shipperNode->appendChild($xml->createElement('EMailAddress', $shipment->getShipper()->getEMailAddress()));
+            $shipperNode->appendChild($xml->createElement('EMailAddress', ($shipment->getShipper()->getEMailAddress()) !== null ? htmlspecialchars($shipment->getShipper()->getEMailAddress()) : null));
         }
 
         $shipperNode->appendChild($shipment->getShipper()->getAddress()->toNode($xml));
 
         $shipToNode = $shipmentNode->appendChild($xml->createElement('ShipTo'));
 
-        $shipToNode->appendChild($xml->createElement('CompanyName', $shipment->getShipTo()->getCompanyName()));
+        $shipToNode->appendChild($xml->createElement('CompanyName', ($shipment->getShipTo()->getCompanyName()) !== null ? htmlspecialchars($shipment->getShipTo()->getCompanyName()) : null));
 
         if ($shipment->getShipTo()->getAttentionName()) {
-            $shipToNode->appendChild($xml->createElement('AttentionName', $shipment->getShipTo()->getAttentionName()));
+            $shipToNode->appendChild($xml->createElement('AttentionName', ($shipment->getShipTo()->getAttentionName()) !== null ? htmlspecialchars($shipment->getShipTo()->getAttentionName()) : null));
         }
 
         if ($shipment->getShipTo()->getPhoneNumber()) {
-            $shipToNode->appendChild($xml->createElement('PhoneNumber', $shipment->getShipTo()->getPhoneNumber()));
+            $shipToNode->appendChild($xml->createElement('PhoneNumber', ($shipment->getShipTo()->getPhoneNumber()) !== null ? htmlspecialchars($shipment->getShipTo()->getPhoneNumber()) : null));
         }
 
         if ($shipment->getShipTo()->getFaxNumber()) {
-            $shipToNode->appendChild($xml->createElement('FaxNumber', $shipment->getShipTo()->getFaxNumber()));
+            $shipToNode->appendChild($xml->createElement('FaxNumber', ($shipment->getShipTo()->getFaxNumber()) !== null ? htmlspecialchars($shipment->getShipTo()->getFaxNumber()) : null));
         }
 
         if ($shipment->getShipTo()->getEMailAddress()) {
-            $shipToNode->appendChild($xml->createElement('EMailAddress', $shipment->getShipTo()->getEMailAddress()));
+            $shipToNode->appendChild($xml->createElement('EMailAddress', ($shipment->getShipTo()->getEMailAddress()) !== null ? htmlspecialchars($shipment->getShipTo()->getEMailAddress()) : null));
         }
 
         $addressNode = $shipment->getShipTo()->getAddress()->toNode($xml);
@@ -207,18 +207,18 @@ class Shipping extends Ups
         if ($shipment->getShipFrom()) {
             $shipFromNode = $shipmentNode->appendChild($xml->createElement('ShipFrom'));
 
-            $shipFromNode->appendChild($xml->createElement('CompanyName', $shipment->getShipFrom()->getCompanyName()));
+            $shipFromNode->appendChild($xml->createElement('CompanyName', ($shipment->getShipFrom()->getCompanyName()) !== null ? htmlspecialchars($shipment->getShipFrom()->getCompanyName()) : null));
 
             if ($shipment->getShipFrom()->getAttentionName()) {
-                $shipFromNode->appendChild($xml->createElement('AttentionName', $shipment->getShipFrom()->getAttentionName()));
+                $shipFromNode->appendChild($xml->createElement('AttentionName', ($shipment->getShipFrom()->getAttentionName()) !== null ? htmlspecialchars($shipment->getShipFrom()->getAttentionName()) : null));
             }
 
             if ($shipment->getShipFrom()->getPhoneNumber()) {
-                $shipFromNode->appendChild($xml->createElement('PhoneNumber', $shipment->getShipFrom()->getPhoneNumber()));
+                $shipFromNode->appendChild($xml->createElement('PhoneNumber', ($shipment->getShipFrom()->getPhoneNumber()) !== null ? htmlspecialchars($shipment->getShipFrom()->getPhoneNumber()) : null));
             }
 
             if ($shipment->getShipFrom()->getFaxNumber()) {
-                $shipFromNode->appendChild($xml->createElement('FaxNumber', $shipment->getShipFrom()->getFaxNumber()));
+                $shipFromNode->appendChild($xml->createElement('FaxNumber', ($shipment->getShipFrom()->getFaxNumber()) !== null ? htmlspecialchars($shipment->getShipFrom()->getFaxNumber()) : null));
             }
 
             if (!empty($shipment->getShipFrom()->getVendorInfo())) {
@@ -232,21 +232,21 @@ class Shipping extends Ups
             $soldToNode = $shipmentNode->appendChild($xml->createElement('SoldTo'));
 
             if ($shipment->getSoldTo()->getOption()) {
-                $soldToNode->appendChild($xml->createElement('Option', $shipment->getSoldTo()->getOption()));
+                $soldToNode->appendChild($xml->createElement('Option', ($shipment->getSoldTo()->getOption()) !== null ? htmlspecialchars($shipment->getSoldTo()->getOption()) : null));
             }
 
-            $soldToNode->appendChild($xml->createElement('CompanyName', $shipment->getSoldTo()->getCompanyName()));
+            $soldToNode->appendChild($xml->createElement('CompanyName', ($shipment->getSoldTo()->getCompanyName()) !== null ? htmlspecialchars($shipment->getSoldTo()->getCompanyName()) : null));
 
             if ($shipment->getSoldTo()->getAttentionName()) {
-                $soldToNode->appendChild($xml->createElement('AttentionName', $shipment->getSoldTo()->getAttentionName()));
+                $soldToNode->appendChild($xml->createElement('AttentionName', ($shipment->getSoldTo()->getAttentionName()) !== null ? htmlspecialchars($shipment->getSoldTo()->getAttentionName()) : null));
             }
 
             if ($shipment->getSoldTo()->getPhoneNumber()) {
-                $soldToNode->appendChild($xml->createElement('PhoneNumber', $shipment->getSoldTo()->getPhoneNumber()));
+                $soldToNode->appendChild($xml->createElement('PhoneNumber', ($shipment->getSoldTo()->getPhoneNumber()) !== null ? htmlspecialchars($shipment->getSoldTo()->getPhoneNumber()) : null));
             }
 
             if ($shipment->getSoldTo()->getFaxNumber()) {
-                $soldToNode->appendChild($xml->createElement('FaxNumber', $shipment->getSoldTo()->getFaxNumber()));
+                $soldToNode->appendChild($xml->createElement('FaxNumber', ($shipment->getSoldTo()->getFaxNumber()) !== null ? htmlspecialchars($shipment->getSoldTo()->getFaxNumber()) : null));
             }
 
             if ($shipment->getSoldTo()->getAddress()) {
@@ -268,15 +268,15 @@ class Shipping extends Ups
 
                 $billShipper = $shipment->getPaymentInformation()->getPrepaid()->getBillShipper();
                 if (isset($billShipper) && $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getAccountNumber()) {
-                    $node->appendChild($xml->createElement('AccountNumber', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getAccountNumber()));
+                    $node->appendChild($xml->createElement('AccountNumber', ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getAccountNumber()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getAccountNumber()) : null));
                 } elseif (isset($billShipper) && $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()) {
                     $ccNode = $node->appendChild($xml->createElement('CreditCard'));
-                    $ccNode->appendChild($xml->createElement('Type', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getType()));
-                    $ccNode->appendChild($xml->createElement('Number', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getNumber()));
-                    $ccNode->appendChild($xml->createElement('ExpirationDate', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getExpirationDate()));
+                    $ccNode->appendChild($xml->createElement('Type', ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getType()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getType()) : null));
+                    $ccNode->appendChild($xml->createElement('Number', ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getNumber()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getNumber()) : null));
+                    $ccNode->appendChild($xml->createElement('ExpirationDate', ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getExpirationDate()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getExpirationDate()) : null));
 
                     if ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getSecurityCode()) {
-                        $ccNode->appendChild($xml->createElement('SecurityCode', $shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getSecurityCode()));
+                        $ccNode->appendChild($xml->createElement('SecurityCode', ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getSecurityCode()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getSecurityCode()) : null));
                     }
 
                     if ($shipment->getPaymentInformation()->getPrepaid()->getBillShipper()->getCreditCard()->getAddress()) {
@@ -286,25 +286,25 @@ class Shipping extends Ups
             } elseif ($shipment->getPaymentInformation()->getBillThirdParty()) {
                 $node = $paymentNode->appendChild($xml->createElement('BillThirdParty'));
                 $btpNode = $node->appendChild($xml->createElement('BillThirdPartyShipper'));
-                $btpNode->appendChild($xml->createElement('AccountNumber', $shipment->getPaymentInformation()->getBillThirdParty()->getAccountNumber()));
+                $btpNode->appendChild($xml->createElement('AccountNumber', ($shipment->getPaymentInformation()->getBillThirdParty()->getAccountNumber()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getBillThirdParty()->getAccountNumber()) : null));
 
                 $tpNode = $btpNode->appendChild($xml->createElement('ThirdParty'));
                 $addressNode = $tpNode->appendChild($xml->createElement('Address'));
 
                 $thirdPartAddress = $shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress();
                 if (isset($thirdPartAddress) && $shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()) {
-                    $addressNode->appendChild($xml->createElement('PostalCode', $shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()));
+                    $addressNode->appendChild($xml->createElement('PostalCode', ($shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()) : null));
                 }
 
-                $addressNode->appendChild($xml->createElement('CountryCode', $shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getCountryCode()));
+                $addressNode->appendChild($xml->createElement('CountryCode', ($shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getCountryCode()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getBillThirdParty()->getThirdPartyAddress()->getCountryCode()) : null));
             } elseif ($shipment->getPaymentInformation()->getFreightCollect()) {
                 $node = $paymentNode->appendChild($xml->createElement('FreightCollect'));
                 $brNode = $node->appendChild($xml->createElement('BillReceiver'));
-                $brNode->appendChild($xml->createElement('AccountNumber', $shipment->getPaymentInformation()->getFreightCollect()->getAccountNumber()));
+                $brNode->appendChild($xml->createElement('AccountNumber', ($shipment->getPaymentInformation()->getFreightCollect()->getAccountNumber()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getFreightCollect()->getAccountNumber()) : null));
 
                 if ($shipment->getPaymentInformation()->getFreightCollect()->getBillReceiverAddress()) {
                     $addressNode = $brNode->appendChild($xml->createElement('Address'));
-                    $addressNode->appendChild($xml->createElement('PostalCode', $shipment->getPaymentInformation()->getFreightCollect()->getBillReceiverAddress()->getPostalCode()));
+                    $addressNode->appendChild($xml->createElement('PostalCode', ($shipment->getPaymentInformation()->getFreightCollect()->getBillReceiverAddress()->getPostalCode()) !== null ? htmlspecialchars($shipment->getPaymentInformation()->getFreightCollect()->getBillReceiverAddress()->getPostalCode()) : null));
                 }
             } elseif ($shipment->getPaymentInformation()->getConsigneeBilled()) {
                 $paymentNode->appendChild($xml->createElement('ConsigneeBilled'));
@@ -334,15 +334,15 @@ class Shipping extends Ups
     
                     $billShipper = $rec->getBillShipper();
                     if (isset($billShipper) && $rec->getBillShipper()->getAccountNumber()) {
-                        $node->appendChild($xml->createElement('AccountNumber', $rec->getBillShipper()->getAccountNumber()));
+                        $node->appendChild($xml->createElement('AccountNumber', ($rec->getBillShipper()->getAccountNumber()) !== null ? htmlspecialchars($rec->getBillShipper()->getAccountNumber()) : null));
                     } elseif (isset($billShipper) && $rec->getBillShipper()->getCreditCard()) {
                         $ccNode = $node->appendChild($xml->createElement('CreditCard'));
-                        $ccNode->appendChild($xml->createElement('Type', $rec->getBillShipper()->getCreditCard()->getType()));
-                        $ccNode->appendChild($xml->createElement('Number', $rec->getBillShipper()->getCreditCard()->getNumber()));
-                        $ccNode->appendChild($xml->createElement('ExpirationDate', $rec->getBillShipper()->getCreditCard()->getExpirationDate()));
+                        $ccNode->appendChild($xml->createElement('Type', ($rec->getBillShipper()->getCreditCard()->getType()) !== null ? htmlspecialchars($rec->getBillShipper()->getCreditCard()->getType()) : null));
+                        $ccNode->appendChild($xml->createElement('Number', ($rec->getBillShipper()->getCreditCard()->getNumber()) !== null ? htmlspecialchars($rec->getBillShipper()->getCreditCard()->getNumber()) : null));
+                        $ccNode->appendChild($xml->createElement('ExpirationDate', ($rec->getBillShipper()->getCreditCard()->getExpirationDate()) !== null ? htmlspecialchars($rec->getBillShipper()->getCreditCard()->getExpirationDate()) : null));
     
                         if ($rec->getBillShipper()->getCreditCard()->getSecurityCode()) {
-                            $ccNode->appendChild($xml->createElement('SecurityCode', $rec->getBillShipper()->getCreditCard()->getSecurityCode()));
+                            $ccNode->appendChild($xml->createElement('SecurityCode', ($rec->getBillShipper()->getCreditCard()->getSecurityCode()) !== null ? htmlspecialchars($rec->getBillShipper()->getCreditCard()->getSecurityCode()) : null));
                         }
     
                         if ($rec->getBillShipper()->getCreditCard()->getAddress()) {
@@ -354,17 +354,17 @@ class Shipping extends Ups
                 } elseif ($rec->getBillThirdParty()) {
                     $node = $node->appendChild($xml->createElement('BillThirdParty'));
                     $btpNode = $node->appendChild($xml->createElement('BillThirdPartyShipper'));
-                    $btpNode->appendChild($xml->createElement('AccountNumber', $rec->getBillThirdParty()->getAccountNumber()));
+                    $btpNode->appendChild($xml->createElement('AccountNumber', ($rec->getBillThirdParty()->getAccountNumber()) !== null ? htmlspecialchars($rec->getBillThirdParty()->getAccountNumber()) : null));
     
                     $tpNode = $btpNode->appendChild($xml->createElement('ThirdParty'));
                     $addressNode = $tpNode->appendChild($xml->createElement('Address'));
     
                     $thirdPartAddress = $rec->getBillThirdParty()->getThirdPartyAddress();
                     if (isset($thirdPartAddress) && $rec->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()) {
-                        $addressNode->appendChild($xml->createElement('PostalCode', $rec->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()));
+                        $addressNode->appendChild($xml->createElement('PostalCode', ($rec->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()) !== null ? htmlspecialchars($rec->getBillThirdParty()->getThirdPartyAddress()->getPostalCode()) : null));
                     }
     
-                    $addressNode->appendChild($xml->createElement('CountryCode', $rec->getBillThirdParty()->getThirdPartyAddress()->getCountryCode()));
+                    $addressNode->appendChild($xml->createElement('CountryCode', ($rec->getBillThirdParty()->getThirdPartyAddress()->getCountryCode()) !== null ? htmlspecialchars($rec->getBillThirdParty()->getThirdPartyAddress()->getCountryCode()) : null));
                 } elseif ($rec->getConsigneeBilled()) {
                     $node->appendChild($xml->createElement('ConsigneeBilled'));
                 }
@@ -379,14 +379,14 @@ class Shipping extends Ups
         }
 
         if ($shipment->getMovementReferenceNumber()) {
-            $shipmentNode->appendChild($xml->createElement('MovementReferenceNumber', $shipment->getMovementReferenceNumber()));
+            $shipmentNode->appendChild($xml->createElement('MovementReferenceNumber', ($shipment->getMovementReferenceNumber()) !== null ? htmlspecialchars($shipment->getMovementReferenceNumber()) : null));
         }
 
         $serviceNode = $shipmentNode->appendChild($xml->createElement('Service'));
-        $serviceNode->appendChild($xml->createElement('Code', $shipment->getService()->getCode()));
+        $serviceNode->appendChild($xml->createElement('Code', ($shipment->getService()->getCode()) !== null ? htmlspecialchars($shipment->getService()->getCode()) : null));
 
         if ($shipment->getService()->getDescription()) {
-            $serviceNode->appendChild($xml->createElement('Description', $shipment->getService()->getDescription()));
+            $serviceNode->appendChild($xml->createElement('Description', ($shipment->getService()->getDescription()) !== null ? htmlspecialchars($shipment->getService()->getDescription()) : null));
         }
 
         if ($shipment->getInvoiceLineTotal()) {
@@ -394,7 +394,7 @@ class Shipping extends Ups
         }
 
         if ($shipment->getNumOfPiecesInShipment()) {
-            $shipmentNode->appendChild($xml->createElement('NumOfPiecesInShipment', $shipment->getNumOfPiecesInShipment()));
+            $shipmentNode->appendChild($xml->createElement('NumOfPiecesInShipment', ($shipment->getNumOfPiecesInShipment()) !== null ? htmlspecialchars($shipment->getNumOfPiecesInShipment()) : null));
         }
 
         if ($shipment->getRateInformation()) {
@@ -435,7 +435,7 @@ class Shipping extends Ups
         }
 
         if ($shipment->getLocale()) {
-            $shipmentNode->appendChild($xml->createElement('Locale', $shipment->getLocale()));
+            $shipmentNode->appendChild($xml->createElement('Locale', ($shipment->getLocale()) !== null ? htmlspecialchars($shipment->getLocale()) : null));
         }
         return $xml->saveXML();
     }
@@ -488,7 +488,7 @@ class Shipping extends Ups
         $request->appendChild($node);
 
         $request->appendChild($xml->createElement('RequestAction', 'ShipAccept'));
-        $container->appendChild($xml->createElement('ShipmentDigest', $shipmentDigest));
+        $container->appendChild($xml->createElement('ShipmentDigest', ($shipmentDigest) !== null ? htmlspecialchars($shipmentDigest) : null));
 
         return $xml->saveXML();
     }
@@ -636,35 +636,35 @@ class Shipping extends Ups
         $request->appendChild($xml->createElement('RequestAction', 'LabelRecovery'));
 
         if (is_string($trackingData)) {
-            $container->appendChild($xml->createElement('TrackingNumber', $trackingData));
+            $container->appendChild($xml->createElement('TrackingNumber', ($trackingData) !== null ? htmlspecialchars($trackingData) : null));
         } elseif (is_array($trackingData)) {
             $referenceNumber = $container->appendChild($xml->createElement('ReferenceNumber'));
-            $referenceNumber->appendChild($xml->createElement('Value', $trackingData['value']));
-            $container->appendChild($xml->createElement('ShipperNumber', $trackingData['shipperNumber']));
+            $referenceNumber->appendChild($xml->createElement('Value', ($trackingData['value']) !== null ? htmlspecialchars($trackingData['value']) : null));
+            $container->appendChild($xml->createElement('ShipperNumber', ($trackingData['shipperNumber']) !== null ? htmlspecialchars($trackingData['shipperNumber']) : null));
         }
 
         if (!empty($labelSpecificationOpts)) {
             $labelSpec = $container->appendChild($xml->createElement('LabelSpecification'));
 
             if (isset($labelSpecificationOpts['userAgent'])) {
-                $labelSpec->appendChild($xml->createElement('HTTPUserAgent', $labelSpecificationOpts['userAgent']));
+                $labelSpec->appendChild($xml->createElement('HTTPUserAgent', ($labelSpecificationOpts['userAgent']) !== null ? htmlspecialchars($labelSpecificationOpts['userAgent']) : null));
             }
 
             if (isset($labelSpecificationOpts['imageFormat'])) {
                 $format = $labelSpec->appendChild($xml->createElement('LabelImageFormat'));
-                $format->appendChild($xml->createElement('Code', $labelSpecificationOpts['imageFormat']));
+                $format->appendChild($xml->createElement('Code', ($labelSpecificationOpts['imageFormat']) !== null ? htmlspecialchars($labelSpecificationOpts['imageFormat']) : null));
             }
         }
 
         if (!empty($labelDeliveryOpts)) {
             $labelDelivery = $container->appendChild($xml->createElement('LabelDelivery'));
-            $labelDelivery->appendChild($xml->createElement('LabelLinkIndicator', $labelDeliveryOpts['link']));
+            $labelDelivery->appendChild($xml->createElement('LabelLinkIndicator', ($labelDeliveryOpts['link']) !== null ? htmlspecialchars($labelDeliveryOpts['link']) : null));
         }
 
         if (!empty($translateOpts)) {
             $translate = $container->appendChild($xml->createElement('Translate'));
-            $translate->appendChild($xml->createElement('LanguageCode', $translateOpts['language']));
-            $translate->appendChild($xml->createElement('DialectCode', $translateOpts['dialect']));
+            $translate->appendChild($xml->createElement('LanguageCode', ($translateOpts['language']) !== null ? htmlspecialchars($translateOpts['language']) : null));
+            $translate->appendChild($xml->createElement('DialectCode', ($translateOpts['dialect']) !== null ? htmlspecialchars($translateOpts['dialect']) : null));
             $translate->appendChild($xml->createElement('Code', '01'));
         }
 
@@ -739,10 +739,10 @@ class Shipping extends Ups
         $receiptSpecNode = $xml->appendChild($xml->createElement('ReceiptSpecification'));
 
         $imageFormatNode = $receiptSpecNode->appendChild($xml->createElement('ImageFormat'));
-        $imageFormatNode->appendChild($xml->createElement('Code', $receiptSpec->getImageFormatCode()));
+        $imageFormatNode->appendChild($xml->createElement('Code', ($receiptSpec->getImageFormatCode()) !== null ? htmlspecialchars($receiptSpec->getImageFormatCode()) : null));
 
         if ($receiptSpec->getImageFormatDescription()) {
-            $imageFormatNode->appendChild($xml->createElement('Description', $receiptSpec->getImageFormatDescription()));
+            $imageFormatNode->appendChild($xml->createElement('Description', ($receiptSpec->getImageFormatDescription()) !== null ? htmlspecialchars($receiptSpec->getImageFormatDescription()) : null));
         }
 
         return $receiptSpecNode->cloneNode(true);
@@ -760,43 +760,43 @@ class Shipping extends Ups
         $labelSpecNode = $xml->appendChild($xml->createElement('LabelSpecification'));
 
         $printMethodNode = $labelSpecNode->appendChild($xml->createElement('LabelPrintMethod'));
-        $printMethodNode->appendChild($xml->createElement('Code', $labelSpec->getPrintMethodCode()));
+        $printMethodNode->appendChild($xml->createElement('Code', ($labelSpec->getPrintMethodCode()) !== null ? htmlspecialchars($labelSpec->getPrintMethodCode()) : null));
 
         if ($labelSpec->getPrintMethodDescription()) {
-            $printMethodNode->appendChild($xml->createElement('Description', $labelSpec->getPrintMethodDescription()));
+            $printMethodNode->appendChild($xml->createElement('Description', ($labelSpec->getPrintMethodDescription()) !== null ? htmlspecialchars($labelSpec->getPrintMethodDescription()) : null));
         }
 
         if ($labelSpec->getHttpUserAgent()) {
-            $labelSpecNode->appendChild($xml->createElement('HTTPUserAgent', $labelSpec->getHttpUserAgent()));
+            $labelSpecNode->appendChild($xml->createElement('HTTPUserAgent', ($labelSpec->getHttpUserAgent()) !== null ? htmlspecialchars($labelSpec->getHttpUserAgent()) : null));
         }
 
         //Label print method is required only for GIF|PNG label formats
         if (!empty($labelSpec->getImageFormatCode())) {
             $imageFormatNode = $labelSpecNode->appendChild($xml->createElement('LabelImageFormat'));
-            $imageFormatNode->appendChild($xml->createElement('Code', $labelSpec->getImageFormatCode()));
+            $imageFormatNode->appendChild($xml->createElement('Code', ($labelSpec->getImageFormatCode()) !== null ? htmlspecialchars($labelSpec->getImageFormatCode()) : null));
 
             if ($labelSpec->getImageFormatDescription()) {
-                $imageFormatNode->appendChild($xml->createElement('Description', $labelSpec->getImageFormatDescription()));
+                $imageFormatNode->appendChild($xml->createElement('Description', ($labelSpec->getImageFormatDescription()) !== null ? htmlspecialchars($labelSpec->getImageFormatDescription()) : null));
             }
         } else {
             //Label stock size is required only for non-IMAGE label formats
             $stockSizeNode = $labelSpecNode->appendChild($xml->createElement('LabelStockSize'));
 
-            $stockSizeNode->appendChild($xml->createElement('Height', $labelSpec->getStockSizeHeight()));
-            $stockSizeNode->appendChild($xml->createElement('Width', $labelSpec->getStockSizeWidth()));
+            $stockSizeNode->appendChild($xml->createElement('Height', ($labelSpec->getStockSizeHeight()) !== null ? htmlspecialchars($labelSpec->getStockSizeHeight()) : null));
+            $stockSizeNode->appendChild($xml->createElement('Width', ($labelSpec->getStockSizeWidth()) !== null ? htmlspecialchars($labelSpec->getStockSizeWidth()) : null));
         }
 
         if ($labelSpec->getInstructionCode()) {
             $instructionNode = $labelSpecNode->appendChild($xml->createElement('Instruction'));
-            $instructionNode->appendChild($xml->createElement('Code', $labelSpec->getInstructionCode()));
+            $instructionNode->appendChild($xml->createElement('Code', ($labelSpec->getInstructionCode()) !== null ? htmlspecialchars($labelSpec->getInstructionCode()) : null));
 
             if ($labelSpec->getInstructionDescription()) {
-                $instructionNode->appendChild($xml->createElement('Description', $labelSpec->getInstructionDescription()));
+                $instructionNode->appendChild($xml->createElement('Description', ($labelSpec->getInstructionDescription()) !== null ? htmlspecialchars($labelSpec->getInstructionDescription()) : null));
             }
         }
         
         if ($labelSpec->getCharacterSet()) {
-            $labelSpecNode->appendChild($xml->createElement('CharacterSet', $labelSpec->getCharacterSet()));
+            $labelSpecNode->appendChild($xml->createElement('CharacterSet', ($labelSpec->getCharacterSet()) !== null ? htmlspecialchars($labelSpec->getCharacterSet()) : null));
         }
 
         return $labelSpecNode->cloneNode(true);

--- a/src/SimpleAddressValidation.php
+++ b/src/SimpleAddressValidation.php
@@ -113,16 +113,16 @@ class SimpleAddressValidation extends Ups
             $addressNode = $avRequest->appendChild($xml->createElement('Address'));
 
             if ($this->address->getStateProvinceCode()) {
-                $addressNode->appendChild($xml->createElement('StateProvinceCode', $this->address->getStateProvinceCode()));
+                $addressNode->appendChild($xml->createElement('StateProvinceCode', ($this->address->getStateProvinceCode()) !== null ? htmlspecialchars($this->address->getStateProvinceCode()) : null));
             }
             if ($this->address->getCity()) {
-                $addressNode->appendChild($xml->createElement('City', $this->address->getCity()));
+                $addressNode->appendChild($xml->createElement('City', ($this->address->getCity()) !== null ? htmlspecialchars($this->address->getCity()) : null));
             }
             if ($this->address->getCountryCode()) {
-                $addressNode->appendChild($xml->createElement('CountryCode', $this->address->getCountryCode()));
+                $addressNode->appendChild($xml->createElement('CountryCode', ($this->address->getCountryCode()) !== null ? htmlspecialchars($this->address->getCountryCode()) : null));
             }
             if ($this->address->getPostalCode()) {
-                $addressNode->appendChild($xml->createElement('PostalCode', $this->address->getPostalCode()));
+                $addressNode->appendChild($xml->createElement('PostalCode', ($this->address->getPostalCode()) !== null ? htmlspecialchars($this->address->getPostalCode()) : null));
             }
         }
 

--- a/src/TimeInTransit.php
+++ b/src/TimeInTransit.php
@@ -119,7 +119,7 @@ class TimeInTransit extends Ups
 
         $packages = $timeInTransitRequest->getTotalPackagesInShipment();
         if (isset($packages)) {
-            $trackRequest->appendChild($xml->createElement('TotalPackagesInShipment', $packages));
+            $trackRequest->appendChild($xml->createElement('TotalPackagesInShipment', ($packages) !== null ? htmlspecialchars($packages) : null));
         }
 
         $invoiceLineTotal = $timeInTransitRequest->getInvoiceLineTotal();
@@ -129,7 +129,7 @@ class TimeInTransit extends Ups
 
         $pickupDate = $timeInTransitRequest->getPickupDate();
         if ($pickupDate) {
-            $trackRequest->appendChild($xml->createElement('PickupDate', $pickupDate->format('Ymd')));
+            $trackRequest->appendChild($xml->createElement('PickupDate', ($pickupDate->format('Ymd')) !== null ? htmlspecialchars($pickupDate->format('Ymd')) : null));
         }
 
         $indicator = $timeInTransitRequest->getDocumentsOnlyIndicator();

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -264,11 +264,11 @@ class Tracking extends Ups
         $request->appendChild($xml->createElement('RequestAction', 'Track'));
 
         if (null !== $this->requestOption) {
-            $request->appendChild($xml->createElement('RequestOption', $this->requestOption));
+            $request->appendChild($xml->createElement('RequestOption', ($this->requestOption) !== null ? htmlspecialchars($this->requestOption) : null));
         }
 
         if (null !== $this->trackingNumber) {
-            $trackRequest->appendChild($xml->createElement('TrackingNumber', $this->trackingNumber));
+            $trackRequest->appendChild($xml->createElement('TrackingNumber', ($this->trackingNumber) !== null ? htmlspecialchars($this->trackingNumber) : null));
         }
 
         if ($this->isMailInnovations()) {
@@ -276,11 +276,11 @@ class Tracking extends Ups
         }
 
         if (null !== $this->referenceNumber) {
-            $trackRequest->appendChild($xml->createElement('ReferenceNumber'))->appendChild($xml->createElement('Value', $this->referenceNumber));
+            $trackRequest->appendChild($xml->createElement('ReferenceNumber'))->appendChild($xml->createElement('Value', ($this->referenceNumber) !== null ? htmlspecialchars($this->referenceNumber) : null));
         }
 
         if (null !== $this->shipperNumber) {
-            $trackRequest->appendChild($xml->createElement('ShipperNumber', $this->shipperNumber));
+            $trackRequest->appendChild($xml->createElement('ShipperNumber', ($this->shipperNumber) !== null ? htmlspecialchars($this->shipperNumber) : null));
         }
 
         if (null !== $this->beginDate || null !== $this->endDate) {
@@ -288,12 +288,12 @@ class Tracking extends Ups
 
             if (null !== $this->beginDate) {
                 $beginDate = $this->beginDate->format('Ymd');
-                $DateRange->appendChild($xml->createElement('BeginDate', $beginDate));
+                $DateRange->appendChild($xml->createElement('BeginDate', ($beginDate) !== null ? htmlspecialchars($beginDate) : null));
             }
 
             if (null !== $this->endDate) {
                 $endDate = $this->endDate->format('Ymd');
-                $DateRange->appendChild($xml->createElement('EndDate', $endDate));
+                $DateRange->appendChild($xml->createElement('EndDate', ($endDate) !== null ? htmlspecialchars($endDate) : null));
             }
 
             $trackRequest->appendChild($DateRange);

--- a/src/Ups.php
+++ b/src/Ups.php
@@ -137,8 +137,8 @@ abstract class Ups implements LoggerAwareInterface
         $accessRequest = $xml->appendChild($xml->createElement('AccessRequest'));
         $accessRequest->setAttribute('xml:lang', 'en-US');
 
-        $accessRequest->appendChild($xml->createElement('AccessLicenseNumber', $this->accessKey));
-        $accessRequest->appendChild($xml->createElement('UserId', $this->userId));
+        $accessRequest->appendChild($xml->createElement('AccessLicenseNumber', ($this->accessKey) !== null ? htmlspecialchars($this->accessKey) : null));
+        $accessRequest->appendChild($xml->createElement('UserId', ($this->userId) !== null ? htmlspecialchars($this->userId) : null));
         
         $p = $accessRequest->appendChild($xml->createElement('Password'));
         $p->appendChild($xml->createTextNode($this->password));
@@ -159,7 +159,7 @@ abstract class Ups implements LoggerAwareInterface
         $trxRef = $xml->appendChild($xml->createElement('TransactionReference'));
 
         if (null !== $this->context) {
-            $trxRef->appendChild($xml->createElement('CustomerContext', $this->context));
+            $trxRef->appendChild($xml->createElement('CustomerContext', ($this->context) !== null ? htmlspecialchars($this->context) : null));
         }
 
         return $trxRef->cloneNode(true);

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -105,7 +105,7 @@ class Utilities
     public static function appendChild(stdClass $object, $propertyName, DOMNode $node)
     {
         if (isset($object->{$propertyName})) {
-            $node->appendChild($node->ownerDocument->createElement($propertyName, $object->{$propertyName}));
+            $node->appendChild($node->ownerDocument->createElement($propertyName, ($object->{$propertyName}) !== null ? htmlspecialchars($object->{$propertyName}) : null));
         }
     }
 }


### PR DESCRIPTION
This is not really a nice fix.
It's just a search and replace for all createElement calls that adds htmlspecialchars everywhere

These were the patterns executed:
`createElement\(([^,()]+\,\s*)(\$([^,;()]+|\([^;()]*\))+)\)` 
`createElement($1($2) !== null ? htmlspecialchars($2) : null)`